### PR TITLE
Windows 7-styled colorization for Legacy branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.vcxproj.user
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -1,0 +1,86 @@
+#include "pch.h"
+#include "ButtonGlowHandler.hpp"
+
+using namespace OpenGlass;
+namespace OpenGlass::ButtonGlowHandler
+{
+	static int MINMAXBUTTONGLOW = 93; //16 in windows 7
+	static int CLOSEBUTTONGLOW = 92; //11 in windows 7
+	static int TOOLCLOSEBUTTONGLOW = 94; //47 in windows 7
+
+	inline __int64(__fastcall* CTopLevelWindow__CreateBitmapFromAtlas)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
+	HRESULT CTopLevelWindow__CreateButtonGlowsFromAtlas(HTHEME hTheme)
+	{
+#ifdef DEBUG
+		OutputDebugStringW(std::format(L"CTopLevelWindow__CreateButtonGlowsFromAtlas").c_str());
+#endif
+		MARGINS margins{};
+		HRESULT hr = S_OK;
+		void* OutBitmapSourceBlue = nullptr;
+		void* OutBitmapSourceRed = nullptr;
+		void* OutBitmapSourceTool = nullptr;
+
+		hr = CTopLevelWindow__CreateBitmapFromAtlas(hTheme, MINMAXBUTTONGLOW, &margins, &OutBitmapSourceBlue);
+		if (hr < 0)
+			return hr;
+		*(MARGINS*)(__int64(OutBitmapSourceBlue) + 0x30) = margins; //offset is the same as w7, so it shouldnt change
+
+		hr = CTopLevelWindow__CreateBitmapFromAtlas(hTheme, CLOSEBUTTONGLOW, &margins, &OutBitmapSourceRed);
+		if (hr < 0)
+			return hr;
+		*(MARGINS*)(__int64(OutBitmapSourceRed) + 0x30) = margins;
+
+		hr = CTopLevelWindow__CreateBitmapFromAtlas(hTheme, TOOLCLOSEBUTTONGLOW, &margins, &OutBitmapSourceTool);
+		if (hr < 0)
+			return hr;
+		*(MARGINS*)(__int64(OutBitmapSourceTool) + 0x30) = margins;
+
+		for (int i = 0; i < 4; ++i)
+		{
+			auto frame = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[i];
+			*(void**)(__int64(frame) + 0xD0) = OutBitmapSourceBlue;
+			*(void**)(__int64(frame) + 0xC8) = OutBitmapSourceRed;
+		}
+		for (int i = 4; i < 6; ++i)
+		{
+			auto frame = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[i];
+			*(void**)(__int64(frame) + 0xD0) = OutBitmapSourceTool;
+			*(void**)(__int64(frame) + 0xC8) = OutBitmapSourceTool;
+		}
+		return hr;
+	}
+
+	HRESULT (__fastcall* CTopLevelWindow_CreateGlyphsFromAtlas)(HTHEME hTheme);
+	HRESULT __fastcall CTopLevelWindow_CreateGlyphsFromAtlas_Hook(HTHEME hTheme)
+	{
+		CTopLevelWindow__CreateButtonGlowsFromAtlas(hTheme);
+		return CTopLevelWindow_CreateGlyphsFromAtlas(hTheme);
+	}
+
+	void UpdateConfiguration(ConfigurationFramework::UpdateType type)
+	{
+		MINMAXBUTTONGLOW = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"MINMAXBUTTONGLOWid",93);
+		CLOSEBUTTONGLOW = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"CLOSEBUTTONGLOWid",92);
+		TOOLCLOSEBUTTONGLOW = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"TOOLCLOSEBUTTONGLOWid",94);
+	}
+
+	HRESULT Startup()
+	{
+		uDwm::GetAddressFromSymbolMap("CTopLevelWindow::CreateBitmapFromAtlas", CTopLevelWindow__CreateBitmapFromAtlas);
+		uDwm::GetAddressFromSymbolMap("CTopLevelWindow::CreateGlyphsFromAtlas", CTopLevelWindow_CreateGlyphsFromAtlas);
+		HookHelper::Detours::Write([]()
+			{
+				HookHelper::Detours::Attach(&CTopLevelWindow_CreateGlyphsFromAtlas, CTopLevelWindow_CreateGlyphsFromAtlas_Hook);
+			});
+
+		return S_OK;
+	}
+
+	void Shutdown()
+	{
+		HookHelper::Detours::Write([]()
+			{
+				HookHelper::Detours::Detach(&CTopLevelWindow_CreateGlyphsFromAtlas, CTopLevelWindow_CreateGlyphsFromAtlas_Hook);
+			});
+	}
+}

--- a/OpenGlass/ButtonGlowHandler.hpp
+++ b/OpenGlass/ButtonGlowHandler.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "framework.hpp"
+#include "ConfigurationFramework.hpp"
+
+namespace OpenGlass::ButtonGlowHandler
+{
+	void UpdateConfiguration(ConfigurationFramework::UpdateType type);
+
+	HRESULT Startup();
+	void Shutdown();
+}

--- a/OpenGlass/CaptionTextHandler.cpp
+++ b/OpenGlass/CaptionTextHandler.cpp
@@ -262,17 +262,11 @@ void CaptionTextHandler::UpdateConfiguration(ConfigurationFramework::UpdateType 
 	}
 }
 
-struct GlowPartDefinition
-{
-	DWORD PartID;
-	DWORD unk1;
-	DWORD unk2;
-	DWORD unk3;
-};
 
-//Remake from w7 udwm
+//TODO: MOVE TO SEPERATE FILE!!
 inline __int64(__fastcall* CTopLevelWindow__CreateBitmapFromAtlas)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
 
+//functional remake from w7 udwm (not 1 to 1 remake, but functions the same)
 HRESULT CTopLevelWindow__CreateButtonGlowsFromAtlas(HTHEME hTheme)
 {
 #ifdef DEBUG
@@ -316,77 +310,6 @@ HRESULT CTopLevelWindow__CreateButtonGlowsFromAtlas(HTHEME hTheme)
 		*(void**)(__int64(frame) + 0xC8) = OutBitmapSourceTool;
 	}
 	return hr;
-	//old attempt at remaking the function from windows 7
-	/*
-	GlowPartDefinition partIds[3] = { {93,92,0,1},{93,92,2,3},{-1,94,4,5} };
-
-	GlowPartDefinition* def = &partIds[0];
-
-	int i = 0;
-
-	void* OutBitmapSource = nullptr;
-	while (1)
-	{
-		OutputDebugStringW(std::format(L"it {}", i).c_str());
-		def = &partIds[i];
-		int partId = def->PartID;
-		if (partId != -1)
-		{
-			hr = CTopLevelWindow__CreateBitmapFromAtlas(hTheme, partId, &margins, &OutBitmapSource);
-			OutputDebugStringW(std::format(L"1outbitmapsource: {}",OutBitmapSource).c_str());
-			if (hr < 0)
-				return hr;
-			
-
-			*(_MARGINS*)(__int64(OutBitmapSource) + 0x30) = margins;
-			if (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)
-			{
-				OutputDebugStringW(std::format(L"def->unk2 {} def->unk3 {}", def->unk2, def->unk3).c_str());
-				auto frame1 = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[def->unk2];
-				auto frame2 = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[def->unk3];
-				OutputDebugStringW(std::format(L"f1 {} f2 {}", frame1, frame2).c_str());
-				*(void**)(__int64(frame1) + 0xD0) = OutBitmapSource;
-				*(void**)(__int64(frame2) + 0xD0) = OutBitmapSource;
-				//*(void**)((*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk2)) + 0xC8) = OutBitmapSource;
-				//*(void**)((*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk3)) + 0xC8) = OutBitmapSource;
-
-				//*(uintptr_t*)(*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk2) + 0xC8i64) = (uintptr_t)OutBitmapSource;
-				//*(uintptr_t*)(*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk3) + 0xC8i64) = (uintptr_t)OutBitmapSource;
-			}
-			else
-				OutputDebugStringW(std::format(L"NULLL FRAMES").c_str());
-
-		}
-		if (partId == -1)
-			break;
-		
-		++i;
-		if (i >= 3)
-			return hr;
-	}
-	def = &partIds[0];
-	hr = CTopLevelWindow__CreateBitmapFromAtlas(hTheme, def->unk1, &margins, &OutBitmapSource);
-	OutputDebugStringW(std::format(L"2outbitmapsource: {}", OutBitmapSource).c_str());
-	if (hr < 0)
-		return hr;
-	*(_MARGINS*)(__int64(OutBitmapSource) + 0x30) = margins;
-	if (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)
-	{
-		OutputDebugStringW(std::format(L"def->unk2 {} def->unk3 {}", def->unk2, def->unk3).c_str());
-		auto frame1 = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[def->unk2];
-		auto frame2 = (*uDwm::CTopLevelWindow::s_rgpwfWindowFrames)[def->unk3];
-		OutputDebugStringW(std::format(L"f1 {} f2 {}", frame1, frame2).c_str());
-		*(void**)(__int64(frame1) + 0xC8) = OutBitmapSource;
-		*(void**)(__int64(frame2) + 0xC8) = OutBitmapSource;
-		//*(uintptr_t*)(*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk2) + 0xC0i64) = (uintptr_t)OutBitmapSource;
-		//*(uintptr_t*)(*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk3) + 0xC0i64) = (uintptr_t)OutBitmapSource;
-		//*(void**)((*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk2)) + 0xC8) = OutBitmapSource;
-		//*(void**)((*(uintptr_t*)(__int64(uDwm::CTopLevelWindow::s_rgpwfWindowFrames) + 8i64 * (unsigned int)def->unk3)) + 0xC8) = OutBitmapSource;
-	}
-	else
-		OutputDebugStringW(std::format(L"NULLL FRAMES").c_str());
-
-	return hr;*/
 }
 
 inline HRESULT(__fastcall* CTopLevelWindow_CreateGlyphsFromAtlas)(HTHEME);

--- a/OpenGlass/ColorEffect.hpp
+++ b/OpenGlass/ColorEffect.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/OpenGlass/ColorEffect.hpp
+++ b/OpenGlass/ColorEffect.hpp
@@ -1,1 +1,0 @@
-#pragma once

--- a/OpenGlass/ConfigurationFramework.cpp
+++ b/OpenGlass/ConfigurationFramework.cpp
@@ -1,6 +1,7 @@
 ﻿#include "pch.h"
 #include "ConfigurationFramework.hpp"
 #include "CaptionTextHandler.hpp"
+#include "ButtonGlowHandler.hpp"
 #include "GlassFramework.hpp"
 #include "GlassRenderer.hpp"
 #include "CustomMsstyleLoader.hpp"
@@ -19,6 +20,7 @@ void ConfigurationFramework::Update(UpdateType type)
 	GlassRenderer::UpdateConfiguration(type);
 	CaptionTextHandler::UpdateConfiguration(type);
 	CustomMsstyleLoader::UpdateConfiguration(type);
+	ButtonGlowHandler::UpdateConfiguration(type);
 	DwmFlush();
 }
 

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -320,7 +320,7 @@ HRESULT CCustomBlurEffect::SetParamsAero()
 	RETURN_IF_FAILED(
 		m_tintEffect->SetValue(
 			D2D1_TINT_PROP_COLOR, 
-			D2D1::Vector4F(116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, 1.0f)
+			D2D1::Vector4F(m_Color.r, m_Color.g, m_Color.b, 1.0f)
 	)
 	);
 

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -301,11 +301,6 @@ HRESULT CCustomBlurEffect::SetParamsAero()
 	
 	// okay my conclusion is that i shouldnt tamper with whatever was already set up (no point in removing the scales or adding gaussian blur)
 	// so since all of the blur work is done here, starting my part of it:
-	
-	// hardcoded values whatever (EDIT: Not Anymore!)
-	//m_colorizationAfterglowBalanceVal = 0.43f;
-	//m_colorizationBlurBalanceVal = 0.796f;
-	//m_colorizationColorBalanceVal = 0.08f;
 
 	// afterglow
 	m_saturationEffect->SetInputEffect(0, m_directionalBlurYEffect.get());

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -53,71 +53,8 @@ HRESULT CCustomBlurEffect::Initialize()
 		)
 	);
 
-	/*
-	RETURN_IF_FAILED(
-		m_cropInputEffect->SetValue(D2D1_PROPERTY_CACHED, TRUE)
-	);*/
-	RETURN_IF_FAILED(
-		m_cropInputEffect->SetValue(
-			D2D1_CROP_PROP_BORDER_MODE,
-			D2D1_BORDER_MODE_SOFT
-		)
-	);
-	m_scaleDownEffect->SetInputEffect(0, m_cropInputEffect.get());
-	RETURN_IF_FAILED(m_scaleDownEffect->SetValue(D2D1_SCALE_PROP_SHARPNESS, 1.f));
-	RETURN_IF_FAILED(
-		m_scaleDownEffect->SetValue(
-			D2D1_SCALE_PROP_BORDER_MODE,
-			D2D1_BORDER_MODE_HARD
-		)
-	);
-	RETURN_IF_FAILED(
-		m_scaleDownEffect->SetValue(
-			D2D1_SCALE_PROP_INTERPOLATION_MODE,
-			D2D1_SCALE_INTERPOLATION_MODE_LINEAR
-		)
-	);
-	m_borderEffect->SetInputEffect(0, m_scaleDownEffect.get());
-	RETURN_IF_FAILED(
-		m_borderEffect->SetValue(
-			D2D1_BORDER_PROP_EDGE_MODE_X,
-			D2D1_BORDER_EDGE_MODE_MIRROR
-		)
-	);
-	RETURN_IF_FAILED(
-		m_borderEffect->SetValue(
-			D2D1_BORDER_PROP_EDGE_MODE_Y,
-			D2D1_BORDER_EDGE_MODE_MIRROR
-		)
-	);
-	m_directionalBlurXEffect->SetInputEffect(0, m_borderEffect.get());
-	RETURN_IF_FAILED(
-		m_directionalBlurXEffect->SetValue(
-			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION,
-			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_X
-		)
-	);
-	m_directionalBlurYEffect->SetInputEffect(0, m_directionalBlurXEffect.get());
-	RETURN_IF_FAILED(
-		m_directionalBlurYEffect->SetValue(
-			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION,
-			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_Y
-		)
-	);
-	m_scaleUpEffect->SetInputEffect(0, m_directionalBlurYEffect.get());
-	RETURN_IF_FAILED(m_scaleUpEffect->SetValue(D2D1_SCALE_PROP_SHARPNESS, 1.f));
-	RETURN_IF_FAILED(
-		m_scaleUpEffect->SetValue(
-			D2D1_SCALE_PROP_BORDER_MODE,
-			D2D1_BORDER_MODE_HARD
-		)
-	);
-	RETURN_IF_FAILED(
-		m_scaleUpEffect->SetValue(
-			D2D1_SCALE_PROP_INTERPOLATION_MODE,
-			D2D1_SCALE_INTERPOLATION_MODE_LINEAR
-		)
-	);
+	SetParams();
+
 	m_initialized = true;
 
 	return S_OK;
@@ -225,7 +162,87 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_cropInputEffect->SetValue(D2D1_PROPERTY_CACHED, TRUE)
 	);*/
 
+	SetParamsAero();
+	
 
+	m_initialized = true;
+
+	return S_OK;
+}
+
+HRESULT CCustomBlurEffect::SetParams()
+{
+	/*
+	RETURN_IF_FAILED(
+	m_cropInputEffect->SetValue(D2D1_PROPERTY_CACHED, TRUE)
+	);*/
+	RETURN_IF_FAILED(
+		m_cropInputEffect->SetValue(
+			D2D1_CROP_PROP_BORDER_MODE,
+			D2D1_BORDER_MODE_SOFT
+	)
+	);
+	m_scaleDownEffect->SetInputEffect(0, m_cropInputEffect.get());
+	RETURN_IF_FAILED(m_scaleDownEffect->SetValue(D2D1_SCALE_PROP_SHARPNESS, 1.f));
+	RETURN_IF_FAILED(
+		m_scaleDownEffect->SetValue(
+			D2D1_SCALE_PROP_BORDER_MODE,
+			D2D1_BORDER_MODE_HARD
+	)
+	);
+	RETURN_IF_FAILED(
+		m_scaleDownEffect->SetValue(
+			D2D1_SCALE_PROP_INTERPOLATION_MODE,
+			D2D1_SCALE_INTERPOLATION_MODE_LINEAR
+	)
+	);
+	m_borderEffect->SetInputEffect(0, m_scaleDownEffect.get());
+	RETURN_IF_FAILED(
+		m_borderEffect->SetValue(
+			D2D1_BORDER_PROP_EDGE_MODE_X,
+			D2D1_BORDER_EDGE_MODE_MIRROR
+	)
+	);
+	RETURN_IF_FAILED(
+		m_borderEffect->SetValue(
+			D2D1_BORDER_PROP_EDGE_MODE_Y,
+			D2D1_BORDER_EDGE_MODE_MIRROR
+	)
+	);
+	m_directionalBlurXEffect->SetInputEffect(0, m_borderEffect.get());
+	RETURN_IF_FAILED(
+		m_directionalBlurXEffect->SetValue(
+			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION,
+			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_X
+	)
+	);
+	m_directionalBlurYEffect->SetInputEffect(0, m_directionalBlurXEffect.get());
+	RETURN_IF_FAILED(
+		m_directionalBlurYEffect->SetValue(
+			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION,
+			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_Y
+	)
+	);
+	m_scaleUpEffect->SetInputEffect(0, m_directionalBlurYEffect.get());
+	RETURN_IF_FAILED(m_scaleUpEffect->SetValue(D2D1_SCALE_PROP_SHARPNESS, 1.f));
+	RETURN_IF_FAILED(
+		m_scaleUpEffect->SetValue(
+			D2D1_SCALE_PROP_BORDER_MODE,
+			D2D1_BORDER_MODE_HARD
+	)
+	);
+	RETURN_IF_FAILED(
+		m_scaleUpEffect->SetValue(
+			D2D1_SCALE_PROP_INTERPOLATION_MODE,
+			D2D1_SCALE_INTERPOLATION_MODE_LINEAR
+	)
+	);
+
+	return S_OK;
+}
+
+HRESULT CCustomBlurEffect::SetParamsAero()
+{
 	// now here we start setting values n shit or atleast the default values
 	// imma have to investigate later in the file whats being done but otherwise
 
@@ -235,7 +252,7 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_cropInputEffect->SetValue(
 			D2D1_CROP_PROP_BORDER_MODE,
 			D2D1_BORDER_MODE_SOFT
-		)
+	)
 	);
 	m_scaleDownEffect->SetInputEffect(0, m_cropInputEffect.get());
 	RETURN_IF_FAILED(m_scaleDownEffect->SetValue(D2D1_SCALE_PROP_SHARPNESS, 1.f));
@@ -243,40 +260,40 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_scaleDownEffect->SetValue(
 			D2D1_SCALE_PROP_BORDER_MODE,
 			D2D1_BORDER_MODE_HARD
-		)
+	)
 	);
 	RETURN_IF_FAILED(
 		m_scaleDownEffect->SetValue(
 			D2D1_SCALE_PROP_INTERPOLATION_MODE,
 			D2D1_SCALE_INTERPOLATION_MODE_ANISOTROPIC
-		)
+	)
 	);
 	m_borderEffect->SetInputEffect(0, m_scaleDownEffect.get());
 	RETURN_IF_FAILED(
 		m_borderEffect->SetValue(
 			D2D1_BORDER_PROP_EDGE_MODE_X, 
 			D2D1_BORDER_EDGE_MODE_MIRROR
-		)
+	)
 	);
 	RETURN_IF_FAILED(
 		m_borderEffect->SetValue(
 			D2D1_BORDER_PROP_EDGE_MODE_Y, 
 			D2D1_BORDER_EDGE_MODE_MIRROR
-		)
+	)
 	);
 	m_directionalBlurXEffect->SetInputEffect(0, m_borderEffect.get());
 	RETURN_IF_FAILED(
 		m_directionalBlurXEffect->SetValue(
 			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION, 
 			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_X
-		)
+	)
 	);
 	m_directionalBlurYEffect->SetInputEffect(0, m_directionalBlurXEffect.get());
 	RETURN_IF_FAILED(
 		m_directionalBlurYEffect->SetValue(
 			D2D1_DIRECTIONALBLURKERNEL_PROP_DIRECTION, 
 			D2D1_DIRECTIONALBLURKERNEL_DIRECTION_Y
-		)
+	)
 	);
 
 
@@ -294,7 +311,7 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_saturationEffect->SetValue(
 			D2D1_SATURATION_PROP_SATURATION, 
 			0.0f
-		)
+	)
 	);
 	
 	m_tintEffect->SetInputEffect(0, m_saturationEffect.get());
@@ -302,22 +319,22 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_tintEffect->SetValue(
 			D2D1_TINT_PROP_COLOR, 
 			D2D1::Vector4F(116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, 1.0f)
-		)
+	)
 	);
 
 	
 	D2D1_MATRIX_5X4_F AfterglowBalanceM = D2D1::Matrix5x4F(m_colorizationAfterglowBalanceVal, 0.f, 0.f, 0.f,   
-													   0.f, m_colorizationAfterglowBalanceVal, 0.f, 0.f,   
-													   0.f, 0.f, m_colorizationAfterglowBalanceVal, 0.f,
-													   0.f, 0.f, 0.f, 1.f,   
-													   0.f, 0.f, 0.f, 0.f);
+														   0.f, m_colorizationAfterglowBalanceVal, 0.f, 0.f,   
+														   0.f, 0.f, m_colorizationAfterglowBalanceVal, 0.f,
+														   0.f, 0.f, 0.f, 1.f,   
+														   0.f, 0.f, 0.f, 0.f);
 
 	m_ColorizationAfterglowBalance->SetInputEffect(0, m_tintEffect.get());
 	RETURN_IF_FAILED(
 		m_ColorizationAfterglowBalance->SetValue(
 			D2D1_COLORMATRIX_PROP_COLOR_MATRIX, 
 			AfterglowBalanceM
-		)
+	)
 	);
 
 	// afterglow done
@@ -326,15 +343,15 @@ HRESULT CCustomBlurEffect::InitializeAero()
 	D2D1_MATRIX_5X4_F BlurBalanceM = D2D1::Matrix5x4F(m_colorizationBlurBalanceVal, 0.f, 0.f, 0.f,
 													  0.f, m_colorizationBlurBalanceVal, 0.f, 0.f,
 													  0.f, 0.f, m_colorizationBlurBalanceVal, 0.f,
-														   0.f, 0.f, 0.f, 1.f,   
-														   0.f, 0.f, 0.f, 0.f);
+													  0.f, 0.f, 0.f, 1.f,   
+													  0.f, 0.f, 0.f, 0.f);
 
 	m_ColorizationBlurBalance->SetInputEffect(0, m_directionalBlurYEffect.get());
 	RETURN_IF_FAILED(
 		m_ColorizationBlurBalance->SetValue(
 			D2D1_COLORMATRIX_PROP_COLOR_MATRIX, 
 			BlurBalanceM
-		)
+	)
 	);
 
 	// and finally ColorizationColor
@@ -343,21 +360,21 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_ColorizationColor->SetValue(
 			D2D1_FLOOD_PROP_COLOR, 
 			D2D1::Vector4F(116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, 1.0f)
-		)
+	)
 	);
 
 	D2D1_MATRIX_5X4_F ColorBalanceM = D2D1::Matrix5x4F(m_colorizationColorBalanceVal, 0.f, 0.f, 0.f,
-													  0.f, m_colorizationColorBalanceVal, 0.f, 0.f,
-													  0.f, 0.f, m_colorizationColorBalanceVal, 0.f,
-													  0.f, 0.f, 0.f, 1.f,   
-													  0.f, 0.f, 0.f, 0.f);
+													   0.f, m_colorizationColorBalanceVal, 0.f, 0.f,
+													   0.f, 0.f, m_colorizationColorBalanceVal, 0.f,
+													   0.f, 0.f, 0.f, 1.f,   
+													   0.f, 0.f, 0.f, 0.f);
 
 	m_ColorizationColorBalance->SetInputEffect(0, m_ColorizationColor.get());
 	RETURN_IF_FAILED(
 		m_ColorizationColorBalance->SetValue(
 			D2D1_COLORMATRIX_PROP_COLOR_MATRIX, 
 			ColorBalanceM
-		)
+	)
 	);
 
 
@@ -368,7 +385,7 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_compositeEffect->SetValue(
 			D2D1_COMPOSITE_PROP_MODE, 
 			D2D1_COMPOSITE_MODE_PLUS
-		)
+	)
 	);
 
 	m_compositeEffect_pass2->SetInputEffect(0, m_compositeEffect.get());
@@ -387,17 +404,15 @@ HRESULT CCustomBlurEffect::InitializeAero()
 		m_scaleUpEffect->SetValue(
 			D2D1_SCALE_PROP_BORDER_MODE,
 			D2D1_BORDER_MODE_HARD
-		)
+	)
 	);
 
 	RETURN_IF_FAILED(
 		m_scaleUpEffect->SetValue(
 			D2D1_SCALE_PROP_INTERPOLATION_MODE,
 			D2D1_SCALE_INTERPOLATION_MODE_ANISOTROPIC
-		)
+	)
 	);
-
-	m_initialized = true;
 
 	return S_OK;
 }
@@ -594,6 +609,12 @@ HRESULT STDMETHODCALLTYPE CCustomBlurEffect::Invalidate(
 			(prescaleAmount.y != finalPrescaleAmount.y) ? D2D1_DIRECTIONALBLURKERNEL_OPTIMIZATION_TRANSFORM_SCALE : D2D1_DIRECTIONALBLURKERNEL_OPTIMIZATION_TRANSFORM_IDENDITY
 		)
 	);
+
+	if (m_type == Type::Blur)
+		RETURN_IF_FAILED(SetParams());
+	else if (m_type == Type::Aero)
+		RETURN_IF_FAILED(SetParamsAero());
+
 #ifdef _DEBUG
 	OutputDebugStringW(
 		std::format(

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -359,7 +359,7 @@ HRESULT CCustomBlurEffect::SetParamsAero()
 	RETURN_IF_FAILED(
 		m_ColorizationColor->SetValue(
 			D2D1_FLOOD_PROP_COLOR, 
-			D2D1::Vector4F(116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, 1.0f)
+			D2D1::Vector4F(m_Color.r, m_Color.g, m_Color.b, 1.0f)
 	)
 	);
 
@@ -446,6 +446,7 @@ HRESULT STDMETHODCALLTYPE CCustomBlurEffect::Invalidate(
 	float colorizationAfterglowBalanceVal,
 	float colorizationBlurBalanceVal,
 	float colorizationColorBalanceVal,
+	D2D1_COLOR_F color,
 	Type type
 )
 {
@@ -457,12 +458,13 @@ HRESULT STDMETHODCALLTYPE CCustomBlurEffect::Invalidate(
 	bool recalculateParams{ false };
 	if (m_blurAmount != blurAmount || m_colorizationAfterglowBalanceVal != colorizationAfterglowBalanceVal || 
 		m_colorizationBlurBalanceVal != colorizationBlurBalanceVal ||
-		m_colorizationColorBalanceVal != colorizationColorBalanceVal)
+		m_colorizationColorBalanceVal != colorizationColorBalanceVal || (m_Color.r != color.r) || (m_Color.g != color.g) || (m_Color.b != color.b) || (m_Color.a != color.a) )
 	{
 		m_blurAmount = blurAmount;
 		m_colorizationAfterglowBalanceVal = colorizationAfterglowBalanceVal;
 		m_colorizationBlurBalanceVal = colorizationBlurBalanceVal;
 		m_colorizationColorBalanceVal = colorizationColorBalanceVal;
+		m_Color = color;
 		recalculateParams = true;
 	}
 	

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -243,7 +243,7 @@ HRESULT CCustomBlurEffect::SetParams()
 
 HRESULT CCustomBlurEffect::SetParamsAero()
 {
-	// now here we start setting values n shit or atleast the default values
+	// now here we start setting values, or atleast the default values
 	// imma have to investigate later in the file whats being done but otherwise
 
 
@@ -297,6 +297,8 @@ HRESULT CCustomBlurEffect::SetParamsAero()
 	);
 
 
+	// CREDITS: @kfh83, @wiktorwiktor12, @TorutheRedFox and @WackyIdeas. special shoutouts to @aubymori and @kawapure for testing/help
+	
 	// okay my conclusion is that i shouldnt tamper with whatever was already set up (no point in removing the scales or adding gaussian blur)
 	// so since all of the blur work is done here, starting my part of it:
 	

--- a/OpenGlass/CustomBlurEffect.cpp
+++ b/OpenGlass/CustomBlurEffect.cpp
@@ -283,10 +283,10 @@ HRESULT CCustomBlurEffect::InitializeAero()
 	// okay my conclusion is that i shouldnt tamper with whatever was already set up (no point in removing the scales or adding gaussian blur)
 	// so since all of the blur work is done here, starting my part of it:
 	
-	// hardcoded values whatever
-	m_colorizationAfterglowBalanceVal = 0.43f;
-	m_colorizationBlurBalanceVal = 0.49f;
-	m_colorizationColorBalanceVal = 0.08f;
+	// hardcoded values whatever (EDIT: Not Anymore!)
+	//m_colorizationAfterglowBalanceVal = 0.43f;
+	//m_colorizationBlurBalanceVal = 0.796f;
+	//m_colorizationColorBalanceVal = 0.08f;
 
 	// afterglow
 	m_saturationEffect->SetInputEffect(0, m_directionalBlurYEffect.get());
@@ -434,9 +434,9 @@ HRESULT STDMETHODCALLTYPE CCustomBlurEffect::Invalidate(
 	Type type
 )
 {
-	colorizationAfterglowBalanceVal = 0.49f;
-	colorizationBlurBalanceVal = 0.796f;
-	colorizationBlurBalanceVal = 0.08f;
+	//colorizationAfterglowBalanceVal = 0.49f;
+	//colorizationBlurBalanceVal = 0.796f;
+	//colorizationColorBalanceVal = 0.08f;
 	if (!inputImage) return S_FALSE;
 
 	bool recalculateParams{ false };

--- a/OpenGlass/CustomBlurEffect.hpp
+++ b/OpenGlass/CustomBlurEffect.hpp
@@ -56,6 +56,16 @@ namespace OpenGlass
 		winrt::com_ptr<ID2D1Effect> m_directionalBlurXEffect{};
 		winrt::com_ptr<ID2D1Effect> m_directionalBlurYEffect{};
 		winrt::com_ptr<ID2D1Effect> m_scaleUpEffect{};
+		
+		// new stuff
+		winrt::com_ptr<ID2D1Effect> m_compositeEffect{};
+		winrt::com_ptr<ID2D1Effect> m_compositeEffect_pass2{};
+		winrt::com_ptr<ID2D1Effect> m_saturationEffect{};
+		winrt::com_ptr<ID2D1Effect> m_tintEffect{};
+		winrt::com_ptr<ID2D1Effect> m_ColorizationAfterglowBalance{};
+		winrt::com_ptr<ID2D1Effect> m_ColorizationBlurBalance{};
+		winrt::com_ptr<ID2D1Effect> m_ColorizationColorBalance{};
+		winrt::com_ptr<ID2D1Effect> m_ColorizationColor{};
 
 		static const float k_optimizations[16];
 		static float DetermineOutputScale(float size, float blurAmount);

--- a/OpenGlass/CustomBlurEffect.hpp
+++ b/OpenGlass/CustomBlurEffect.hpp
@@ -80,6 +80,8 @@ namespace OpenGlass
 		static float DetermineOutputScale(float size, float blurAmount);
 		HRESULT Initialize();
 		HRESULT InitializeAero();
+		HRESULT SetParams();
+		HRESULT SetParamsAero();
 	public:
 		CCustomBlurEffect(ID2D1DeviceContext* deviceContext);
 

--- a/OpenGlass/CustomBlurEffect.hpp
+++ b/OpenGlass/CustomBlurEffect.hpp
@@ -2,6 +2,7 @@
 #include "pch.h"
 #include "framework.hpp"
 #include "cpprt.hpp"
+#include "GlassSharedStructures.hpp"
 
 namespace OpenGlass
 {

--- a/OpenGlass/CustomBlurEffect.hpp
+++ b/OpenGlass/CustomBlurEffect.hpp
@@ -35,6 +35,7 @@ namespace OpenGlass
 			float colorizationAfterglowBalanceVal,
 			float colorizationBlurBalanceVal,
 			float colorizationColorBalanceVal,
+			D2D1_COLOR_F color,
 			Type type
 		) = 0;
 		virtual HRESULT STDMETHODCALLTYPE Draw(
@@ -75,6 +76,7 @@ namespace OpenGlass
 		float m_colorizationAfterglowBalanceVal = 0.43f;
 		float m_colorizationBlurBalanceVal = 0.49f;
 		float m_colorizationColorBalanceVal = 0.08f;
+		D2D1_COLOR_F m_Color = { 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f,1.0f };
 
 		static const float k_optimizations[16];
 		static float DetermineOutputScale(float size, float blurAmount);
@@ -93,6 +95,7 @@ namespace OpenGlass
 			float colorizationAfterglowBalanceVal,
 			float colorizationBlurBalanceVal,
 			float colorizationColorBalanceVal,
+			D2D1_COLOR_F color,
 			Type type
 		) override;
 		HRESULT STDMETHODCALLTYPE Draw(

--- a/OpenGlass/CustomBlurEffect.hpp
+++ b/OpenGlass/CustomBlurEffect.hpp
@@ -23,7 +23,7 @@ namespace OpenGlass
 		D2D1_DIRECTIONALBLURKERNEL_OPTIMIZATION_TRANSFORM_IDENDITY,
 		D2D1_DIRECTIONALBLURKERNEL_OPTIMIZATION_TRANSFORM_SCALE
 	};
-
+	
 	// [Guid("01AA613C-2376-4B95-8A74-B94CA840D4D1")]
 	DECLARE_INTERFACE_IID_(ICustomBlurEffect, IUnknown, "01AA613C-2376-4B95-8A74-B94CA840D4D1")
 	{
@@ -31,7 +31,11 @@ namespace OpenGlass
 			ID2D1Image* inputImage,
 			const D2D1_RECT_F& imageRectangle,
 			const D2D1_RECT_F& imageBounds,
-			float blurAmount
+			float blurAmount,
+			float colorizationAfterglowBalanceVal,
+			float colorizationBlurBalanceVal,
+			float colorizationColorBalanceVal,
+			Type type
 		) = 0;
 		virtual HRESULT STDMETHODCALLTYPE Draw(
 			CONST D2D1_RECT_F & bounds,
@@ -46,6 +50,7 @@ namespace OpenGlass
 	{
 		bool m_initialized{ false };
 		float m_blurAmount{ 9.f };
+		Type m_type{Type::Blur};
 		D2D1_RECT_F m_imageRectangle{};
 		ID2D1Image* m_effectInput{ nullptr };
 		winrt::com_ptr<ID2D1Image> m_effectOutput{ nullptr };
@@ -67,9 +72,14 @@ namespace OpenGlass
 		winrt::com_ptr<ID2D1Effect> m_ColorizationColorBalance{};
 		winrt::com_ptr<ID2D1Effect> m_ColorizationColor{};
 
+		float m_colorizationAfterglowBalanceVal = 0.43f;
+		float m_colorizationBlurBalanceVal = 0.49f;
+		float m_colorizationColorBalanceVal = 0.08f;
+
 		static const float k_optimizations[16];
 		static float DetermineOutputScale(float size, float blurAmount);
 		HRESULT Initialize();
+		HRESULT InitializeAero();
 	public:
 		CCustomBlurEffect(ID2D1DeviceContext* deviceContext);
 
@@ -77,7 +87,11 @@ namespace OpenGlass
 			ID2D1Image* inputImage,
 			const D2D1_RECT_F& imageRectangle,
 			const D2D1_RECT_F& imageBounds,
-			float blurAmount
+			float blurAmount,
+			float colorizationAfterglowBalanceVal,
+			float colorizationBlurBalanceVal,
+			float colorizationColorBalanceVal,
+			Type type
 		) override;
 		HRESULT STDMETHODCALLTYPE Draw(
 			CONST D2D1_RECT_F& bounds,

--- a/OpenGlass/GlassEffectManager.cpp
+++ b/OpenGlass/GlassEffectManager.cpp
@@ -216,6 +216,7 @@ HRESULT STDMETHODCALLTYPE GlassEffectManager::CGlassEffect::Invalidate(
 				m_colorizationAfterglowBalanceVal,
 				m_colorizationBlurBalanceVal,
 				m_colorizationColorBalanceVal,
+				m_color,
 				m_type
 			)
 		);

--- a/OpenGlass/GlassEffectManager.cpp
+++ b/OpenGlass/GlassEffectManager.cpp
@@ -28,6 +28,10 @@ namespace OpenGlass::GlassEffectManager
 		winrt::com_ptr<ID2D1Bitmap1> m_blurBuffer{ nullptr };
 		winrt::com_ptr<ICustomBlurEffect> m_customBlurEffect{ nullptr };
 
+		float m_colorizationAfterglowBalanceVal;
+		float m_colorizationBlurBalanceVal;
+		float m_colorizationColorBalanceVal;
+
 		HRESULT Initialize();
 	public:
 		CGlassEffect(ID2D1DeviceContext* deviceContext) { winrt::copy_from_abi(m_deviceContext, deviceContext); }
@@ -35,7 +39,11 @@ namespace OpenGlass::GlassEffectManager
 		void STDMETHODCALLTYPE SetGlassRenderingParameters(
 			const D2D1_COLOR_F& color,
 			float glassOpacity,
-			float blurAmount
+			float blurAmount,
+			float colorizationAfterglowBalanceVal,
+			float colorizationBlurBalanceVal,
+			float colorizationColorBalanceVal,
+			Type type
 		) override;
 		void STDMETHODCALLTYPE SetSize(const D2D1_SIZE_F& size) override;
 		HRESULT STDMETHODCALLTYPE Invalidate(
@@ -57,12 +65,20 @@ HRESULT GlassEffectManager::CGlassEffect::Initialize()
 void STDMETHODCALLTYPE GlassEffectManager::CGlassEffect::SetGlassRenderingParameters(
 	const D2D1_COLOR_F& color,
 	float glassOpacity,
-	float blurAmount
+	float blurAmount,
+	float colorizationAfterglowBalanceVal,
+	float colorizationBlurBalanceVal,
+	float colorizationColorBalanceVal,
+	Type type
 )
 {
 	m_color = color;
 	m_glassOpacity = glassOpacity;
 	m_blurAmount = blurAmount;
+	m_colorizationAfterglowBalanceVal = colorizationAfterglowBalanceVal;
+	m_colorizationBlurBalanceVal = colorizationBlurBalanceVal;
+	m_colorizationColorBalanceVal = colorizationColorBalanceVal;
+	m_type = type;
 }
 void STDMETHODCALLTYPE GlassEffectManager::CGlassEffect::SetSize(const D2D1_SIZE_F& size)
 {
@@ -196,7 +212,11 @@ HRESULT STDMETHODCALLTYPE GlassEffectManager::CGlassEffect::Invalidate(
 				m_blurBuffer.get(),
 				invalidInputRect,
 				imageBounds,
-				m_blurAmount
+				m_blurAmount,
+				m_colorizationAfterglowBalanceVal,
+				m_colorizationBlurBalanceVal,
+				m_colorizationColorBalanceVal,
+				m_type
 			)
 		);
 	}

--- a/OpenGlass/GlassEffectManager.cpp
+++ b/OpenGlass/GlassEffectManager.cpp
@@ -5,6 +5,7 @@
 #include "GlassEffectManager.hpp"
 #include "ReflectionRenderer.hpp"
 #include "CustomBlurEffect.hpp"
+#include "GlassSharedStructures.hpp"
 
 using namespace OpenGlass;
 namespace OpenGlass::GlassEffectManager

--- a/OpenGlass/GlassEffectManager.hpp
+++ b/OpenGlass/GlassEffectManager.hpp
@@ -5,11 +5,6 @@
 
 namespace OpenGlass::GlassEffectManager
 {
-	enum class Type : UCHAR
-	{
-		Blur,
-		Aero
-	};
 
 	// [Guid("01AA613C-2376-4B95-8A74-B94CA840D4D1")]
 	DECLARE_INTERFACE_IID_(IGlassEffect, IUnknown, "01AA613C-2376-4B95-8A74-B94CA840D4D1")
@@ -17,7 +12,11 @@ namespace OpenGlass::GlassEffectManager
 		virtual void STDMETHODCALLTYPE SetGlassRenderingParameters(
 			const D2D1_COLOR_F& color,
 			float glassOpacity,
-			float blurAmount
+			float blurAmount,
+			float colorizationAfterglowBalanceVal,
+			float colorizationBlurBalanceVal,
+			float colorizationColorBalanceVal,
+			Type type
 		) = 0;
 		virtual void STDMETHODCALLTYPE SetSize(const D2D1_SIZE_F& size) = 0;
 		virtual HRESULT STDMETHODCALLTYPE Invalidate(

--- a/OpenGlass/GlassEffectManager.hpp
+++ b/OpenGlass/GlassEffectManager.hpp
@@ -2,6 +2,7 @@
 #include "framework.hpp"
 #include "cpprt.hpp"
 #include "uDwmProjection.hpp"
+#include "GlassSharedStructures.hpp"
 
 namespace OpenGlass::GlassEffectManager
 {

--- a/OpenGlass/GlassFramework.cpp
+++ b/OpenGlass/GlassFramework.cpp
@@ -343,8 +343,8 @@ void GlassFramework::UpdateConfiguration(ConfigurationFramework::UpdateType type
 	GlassSharedData::g_ColorizationBlurBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationBlurBalance",49) / 100);
 	GlassSharedData::g_ColorizationColorBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationColorBalance",8) / 100);
 
-	DWORD hexColour = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"AccentColor", 0xfffcb874);
-	GlassSharedData::g_AccentColor = Utils::FromAbgr(hexColour);
+	DWORD hexColour = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"ColorizationColor", 0xfffcb874);
+	GlassSharedData::g_ColorizationColor = Utils::FromArgb(hexColour);
 
 	auto lock{ wil::EnterCriticalSection(uDwm::CDesktopManager::s_csDwmInstance) };
 	if (!GlassSharedData::IsBackdropAllowed())

--- a/OpenGlass/GlassFramework.cpp
+++ b/OpenGlass/GlassFramework.cpp
@@ -67,6 +67,7 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCDrawGeometryInstruction_Create(uDwm
 			);
 			auto color{ g_capturedWindow->GetTitlebarColorizationParameters()->getArgbcolor() };
 			color.a *= 0.99f;
+			color.r = g_capturedWindow->TreatAsActiveWindow();
 			RETURN_IF_FAILED(solidBrush->Update(1.0, color));
 			return g_CDrawGeometryInstruction_Create_Org(solidBrush.get(), rgnGeometry.get(), instruction);
 		}
@@ -251,6 +252,7 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCRenderDataVisual_AddInstruction(uDw
 	}
 
 	color.a = 0.99f;
+	color.r = 1.0f;
 	winrt::com_ptr<uDwm::CRgnGeometryProxy> rgnGeometry{ nullptr };
 	uDwm::ResourceHelper::CreateGeometryFromHRGN(wil::unique_hrgn{ CreateRectRgn(static_cast<LONG>(rectangle.left), static_cast<LONG>(rectangle.top), static_cast<LONG>(rectangle.right), static_cast<LONG>(rectangle.bottom)) }.get(), rgnGeometry.put());
 	winrt::com_ptr<uDwm::CSolidColorLegacyMilBrushProxy> solidBrush{ nullptr };
@@ -340,6 +342,9 @@ void GlassFramework::UpdateConfiguration(ConfigurationFramework::UpdateType type
 	GlassSharedData::g_ColorizationAfterglowBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationAfterglowBalance",43) / 100);
 	GlassSharedData::g_ColorizationBlurBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationBlurBalance",49) / 100);
 	GlassSharedData::g_ColorizationColorBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationColorBalance",8) / 100);
+
+	DWORD hexColour = ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"AccentColor", 0xfffcb874);
+	GlassSharedData::g_AccentColor = Utils::FromAbgr(hexColour);
 
 	auto lock{ wil::EnterCriticalSection(uDwm::CDesktopManager::s_csDwmInstance) };
 	if (!GlassSharedData::IsBackdropAllowed())

--- a/OpenGlass/GlassFramework.cpp
+++ b/OpenGlass/GlassFramework.cpp
@@ -332,6 +332,10 @@ void GlassFramework::UpdateConfiguration(ConfigurationFramework::UpdateType type
 		g_roundRectRadius = static_cast<int>(ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"RoundRectRadius"));
 	}
 
+	GlassSharedData::g_ColorizationAfterglowBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationAfterglowBalance",43) / 100);
+	GlassSharedData::g_ColorizationBlurBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationBlurBalance",49) / 100);
+	GlassSharedData::g_ColorizationColorBalance = ((float)ConfigurationFramework::DwmGetDwordFromHKCUAndHKLM(L"OG_ColorizationColorBalance",8) / 100);
+
 	auto lock{ wil::EnterCriticalSection(uDwm::CDesktopManager::s_csDwmInstance) };
 	if (!GlassSharedData::IsBackdropAllowed())
 	{

--- a/OpenGlass/GlassFramework.cpp
+++ b/OpenGlass/GlassFramework.cpp
@@ -81,11 +81,13 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCTopLevelWindow_UpdateNCAreaBackgrou
 {
 	if (!GlassSharedData::IsBackdropAllowed())
 	{
+		GlassSharedData::g_LastTopLevelWindow = 0;
 		return g_CTopLevelWindow_UpdateNCAreaBackground_Org(This);
 	}
 	auto data{ This->GetData() };
 	if (!data)
 	{
+		GlassSharedData::g_LastTopLevelWindow = 0;
 		return g_CTopLevelWindow_UpdateNCAreaBackground_Org(This);
 	}
 
@@ -123,6 +125,7 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCTopLevelWindow_UpdateNCAreaBackgrou
 				HRGN borderRegion{ GeometryRecorder::GetRegionFromGeometry(borderGeometry) };
 				
 				hr = legacyVisualOverride->UpdateNCBackground(captionRegion, borderRegion);
+				GlassSharedData::g_LastTopLevelWindow = This;
 			}
 		}
 
@@ -130,6 +133,7 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCTopLevelWindow_UpdateNCAreaBackgrou
 	}
 	else
 	{
+		GlassSharedData::g_LastTopLevelWindow = 0;
 		VisualManager::RemoveLegacyVisualOverrider(This);
 		hr = g_CTopLevelWindow_UpdateNCAreaBackground_Org(This);
 	}
@@ -152,6 +156,7 @@ HRESULT STDMETHODCALLTYPE GlassFramework::MyCTopLevelWindow_UpdateClientBlur(uDw
 
 	g_capturedWindow = This;
 	GeometryRecorder::BeginCapture();
+	GlassSharedData::g_LastTopLevelWindow = 0;
 	HRESULT hr{ g_CTopLevelWindow_UpdateClientBlur_Org(This) };
 	GeometryRecorder::EndCapture();
 	g_capturedWindow = nullptr;

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -153,6 +153,9 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawSolidRectangle(
 	g_drawColor = std::nullopt;
 	return g_CDrawingContext_DrawSolidRectangle_Org(This, rectangle, convertedColor);
 }
+
+bool active = false;
+
 HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	dwmcore::IDrawingContext* This,
 	dwmcore::CLegacyMilBrush* brush,
@@ -236,9 +239,12 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	This->GetDrawingContext()->GetD2DContext()->GetDeviceContext()->GetTarget(backdropImage.put());
 	winrt::com_ptr<ID2D1Bitmap1> backdropBitmap{ backdropImage.as<ID2D1Bitmap1>() };
 	RETURN_IF_FAILED(This->GetDrawingContext()->FlushD2D());
+	//TODO: ADD PROPER TYPE CHECKED CAST 
+	bool bactive = false;
+	if (GlassSharedData::g_LastTopLevelWindow)
+		bactive = (reinterpret_cast<uDwm::CTopLevelWindow*>(GlassSharedData::g_LastTopLevelWindow)->TreatAsActiveWindow());
 
-	//TODO: idk if this is best, prob change
-	bool active = true;
+	//bool bactive = true;
 
 	dwmcore::CMILMatrix matrix{};
 	D2D1_RECT_F shapeWorldBounds{};
@@ -249,7 +255,7 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 		g_glassOpacity,
 		g_blurAmount,
 		GlassSharedData::g_ColorizationAfterglowBalance,
-		active ? GlassSharedData::g_ColorizationBlurBalance : 0.4f * GlassSharedData::g_ColorizationBlurBalance + 0.6f,
+		bactive ? GlassSharedData::g_ColorizationBlurBalance : 0.4f * GlassSharedData::g_ColorizationBlurBalance + 0.6f,
 		GlassSharedData::g_ColorizationColorBalance,
 		g_type
 	);
@@ -317,6 +323,7 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDirtyRegion__Add(
 		lprc.right + extendAmount,
 		lprc.bottom + extendAmount
 	};
+	active = unknown;
 	return g_CDirtyRegion__Add_Org(
 		This,
 		visual,

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -172,16 +172,22 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	{
 		return hr;
 	}
-
+	//HWND hwnd = reinterpret_cast<dwmcore::CDrawingContext*>(This->GetDrawingContext()->GetD2DContextOwner())->GetCurrentVisual()->GetTopLevelWindow();
+	//uDwm::CWindowData* data{ nullptr };
+	//{
+	//	auto lock{ wil::EnterCriticalSection(uDwm::CDesktopManager::s_csDwmInstance) };
+	//	uDwm::CDesktopManager::s_pDesktopManagerInstance->GetWindowList()->GetSyncedWindowDataByHwnd(hwnd, &data);
+	//}
+	//if (!data) return hr;
 	bool bactive = g_drawColor.value().r == 1.0f; //HACK!!!: check if window is active using the data sent through the red channel
 	//bool bactive = data->GetWindow()->TreatAsActiveWindow();
 	//OutputDebugStringW(std::format(L"r {}", g_drawColor.value().r).c_str());
 	//g_drawColor.value() = D2D1_COLOR_F{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, g_drawColor.value().a};
-	//g_drawColor.value() = D2D1_COLOR_F{ GlassSharedData::g_AccentColor.r, GlassSharedData::g_AccentColor.g, GlassSharedData::g_AccentColor.b, g_drawColor.value().a};
+	//g_drawColor.value() = D2D1_COLOR_F{ GlassSharedData::g_ColorizationColor.r, GlassSharedData::g_ColorizationColor.g, GlassSharedData::g_ColorizationColor.b, g_drawColor.value().a};
 	auto cleanUp{ wil::scope_exit([]{ g_drawColor = std::nullopt; })};
 	//D2D1_COLOR_F color{ dwmcore::Convert_D2D1_COLOR_F_scRGB_To_D2D1_COLOR_F_sRGB(g_drawColor.value()) };
 	//D2D1_COLOR_F color{ g_drawColor.value()};
-	D2D1_COLOR_F color{ GlassSharedData::g_AccentColor.r, GlassSharedData::g_AccentColor.g, GlassSharedData::g_AccentColor.b, g_drawColor.value().a };
+	D2D1_COLOR_F color{ GlassSharedData::g_ColorizationColor.r, GlassSharedData::g_ColorizationColor.g, GlassSharedData::g_ColorizationColor.b, g_drawColor.value().a };
 	dwmcore::CShapePtr geometryShape{};
 	if (
 		FAILED(geometry->GetShapeData(nullptr, &geometryShape)) ||

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -6,6 +6,7 @@
 #include "GlassEffectManager.hpp"
 #include "GlassSharedData.hpp"
 #include "ReflectionRenderer.hpp"
+#include "GlassSharedStructures.hpp"
 
 using namespace OpenGlass;
 

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -238,7 +238,7 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	RETURN_IF_FAILED(This->GetDrawingContext()->FlushD2D());
 
 	//TODO: idk if this is best, prob change
-	bool active = false;
+	bool active = true;
 
 	dwmcore::CMILMatrix matrix{};
 	D2D1_RECT_F shapeWorldBounds{};

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -173,8 +173,15 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 		return hr;
 	}
 
+	bool bactive = g_drawColor.value().r == 1.0f; //HACK!!!: check if window is active using the data sent through the red channel
+	//bool bactive = data->GetWindow()->TreatAsActiveWindow();
+	//OutputDebugStringW(std::format(L"r {}", g_drawColor.value().r).c_str());
+	//g_drawColor.value() = D2D1_COLOR_F{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f, g_drawColor.value().a};
+	//g_drawColor.value() = D2D1_COLOR_F{ GlassSharedData::g_AccentColor.r, GlassSharedData::g_AccentColor.g, GlassSharedData::g_AccentColor.b, g_drawColor.value().a};
 	auto cleanUp{ wil::scope_exit([]{ g_drawColor = std::nullopt; })};
-	D2D1_COLOR_F color{ dwmcore::Convert_D2D1_COLOR_F_scRGB_To_D2D1_COLOR_F_sRGB(g_drawColor.value()) };
+	//D2D1_COLOR_F color{ dwmcore::Convert_D2D1_COLOR_F_scRGB_To_D2D1_COLOR_F_sRGB(g_drawColor.value()) };
+	//D2D1_COLOR_F color{ g_drawColor.value()};
+	D2D1_COLOR_F color{ GlassSharedData::g_AccentColor.r, GlassSharedData::g_AccentColor.g, GlassSharedData::g_AccentColor.b, g_drawColor.value().a };
 	dwmcore::CShapePtr geometryShape{};
 	if (
 		FAILED(geometry->GetShapeData(nullptr, &geometryShape)) ||
@@ -238,11 +245,12 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	winrt::com_ptr<ID2D1Image> backdropImage{};
 	This->GetDrawingContext()->GetD2DContext()->GetDeviceContext()->GetTarget(backdropImage.put());
 	winrt::com_ptr<ID2D1Bitmap1> backdropBitmap{ backdropImage.as<ID2D1Bitmap1>() };
-	RETURN_IF_FAILED(This->GetDrawingContext()->FlushD2D());
 	//TODO: ADD PROPER TYPE CHECKED CAST 
-	bool bactive = false;
-	if (GlassSharedData::g_LastTopLevelWindow)
-		bactive = (reinterpret_cast<uDwm::CTopLevelWindow*>(GlassSharedData::g_LastTopLevelWindow)->TreatAsActiveWindow());
+	//bool bactive = false;
+	//if (This->GetDrawingContext()->GetCurrentVisual())
+		//bactive = true;
+
+	RETURN_IF_FAILED(This->GetDrawingContext()->FlushD2D());
 
 	//bool bactive = true;
 

--- a/OpenGlass/GlassRenderer.cpp
+++ b/OpenGlass/GlassRenderer.cpp
@@ -265,7 +265,7 @@ HRESULT STDMETHODCALLTYPE GlassRenderer::MyCDrawingContext_DrawGeometry(
 	RETURN_IF_FAILED(geometryShape->GetTightBounds(&shapeWorldBounds, &matrix));
 	glassEffect->SetGlassRenderingParameters(
 		color,
-		g_glassOpacity,
+		((GlassSharedData::g_type == Type::Aero) ? 0.0f : g_glassOpacity),
 		g_blurAmount,
 		GlassSharedData::g_ColorizationAfterglowBalance,									// stays the same
 		bactive ? GlassSharedData::g_ColorizationBlurBalance : 0.4f * GlassSharedData::g_ColorizationBlurBalance + 0.6f,	// y = 0.4x + 60

--- a/OpenGlass/GlassSharedData.hpp
+++ b/OpenGlass/GlassSharedData.hpp
@@ -12,6 +12,7 @@ namespace OpenGlass::GlassSharedData
 	inline float g_ColorizationAfterglowBalance = 0.43f;
 	inline float g_ColorizationBlurBalance = 0.49f;
 	inline float g_ColorizationColorBalance = 0.08f;
+	inline D2D_COLOR_F g_AccentColor{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f,1.0f };
 
 	FORCEINLINE bool IsBackdropAllowed()
 	{

--- a/OpenGlass/GlassSharedData.hpp
+++ b/OpenGlass/GlassSharedData.hpp
@@ -12,7 +12,7 @@ namespace OpenGlass::GlassSharedData
 	inline float g_ColorizationAfterglowBalance = 0.43f;
 	inline float g_ColorizationBlurBalance = 0.49f;
 	inline float g_ColorizationColorBalance = 0.08f;
-	inline D2D_COLOR_F g_AccentColor{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f,1.0f };
+	inline D2D_COLOR_F g_ColorizationColor{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f,1.0f };
 
 	FORCEINLINE bool IsBackdropAllowed()
 	{

--- a/OpenGlass/GlassSharedData.hpp
+++ b/OpenGlass/GlassSharedData.hpp
@@ -4,6 +4,7 @@
 
 namespace OpenGlass::GlassSharedData
 {
+	inline void* g_LastTopLevelWindow = nullptr;
 	inline bool g_disableOnBattery{ true };
 	inline bool g_overrideAccent{ false };
 	inline bool g_batteryMode{ false };

--- a/OpenGlass/GlassSharedData.hpp
+++ b/OpenGlass/GlassSharedData.hpp
@@ -1,10 +1,10 @@
 ﻿#pragma once
 #include "framework.hpp"
 #include "cpprt.hpp"
+#include "GlassSharedStructures.hpp"
 
 namespace OpenGlass::GlassSharedData
 {
-	inline void* g_LastTopLevelWindow = nullptr;
 	inline bool g_disableOnBattery{ true };
 	inline bool g_overrideAccent{ false };
 	inline bool g_batteryMode{ false };
@@ -13,6 +13,7 @@ namespace OpenGlass::GlassSharedData
 	inline float g_ColorizationBlurBalance = 0.49f;
 	inline float g_ColorizationColorBalance = 0.08f;
 	inline D2D_COLOR_F g_ColorizationColor{ 116.0f / 255.0f, 184.0f / 255.0f, 252.0f / 255.0f,1.0f };
+	inline Type g_type{ Type::Blur };
 
 	FORCEINLINE bool IsBackdropAllowed()
 	{

--- a/OpenGlass/GlassSharedData.hpp
+++ b/OpenGlass/GlassSharedData.hpp
@@ -8,6 +8,9 @@ namespace OpenGlass::GlassSharedData
 	inline bool g_overrideAccent{ false };
 	inline bool g_batteryMode{ false };
 	inline bool g_transparencyEnabled{ true };
+	inline float g_ColorizationAfterglowBalance = 0.43f;
+	inline float g_ColorizationBlurBalance = 0.49f;
+	inline float g_ColorizationColorBalance = 0.08f;
 
 	FORCEINLINE bool IsBackdropAllowed()
 	{

--- a/OpenGlass/GlassSharedStructures.hpp
+++ b/OpenGlass/GlassSharedStructures.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace OpenGlass
+{
+	enum class Type : unsigned char
+	{
+		Blur = 0,
+		Aero = 1
+	};
+}

--- a/OpenGlass/OpenGlass.cpp
+++ b/OpenGlass/OpenGlass.cpp
@@ -9,6 +9,7 @@
 #include "dwmcoreProjection.hpp"
 #include "GeometryRecorder.hpp"
 #include "CaptionTextHandler.hpp"
+#include "ButtonGlowHandler.hpp"
 #include "GlassFramework.hpp"
 #include "GlassRenderer.hpp"
 #include "CustomMsstyleLoader.hpp"
@@ -422,6 +423,7 @@ do_dwmcore_symbol_parsing:
 	GlassFramework::Startup();
 	GlassRenderer::Startup();
 	CaptionTextHandler::Startup();
+	ButtonGlowHandler::Startup();
 	GeometryRecorder::Startup();
 	CustomMsstyleLoader::Startup();
 	ConfigurationFramework::Load();
@@ -516,6 +518,7 @@ void OpenGlass::Shutdown()
 
 	GeometryRecorder::Shutdown();
 	CaptionTextHandler::Shutdown();
+	ButtonGlowHandler::Shutdown();
 	GlassRenderer::Shutdown();
 	GlassFramework::Shutdown();
 	CustomMsstyleLoader::Shutdown();

--- a/OpenGlass/OpenGlass.vcxproj
+++ b/OpenGlass/OpenGlass.vcxproj
@@ -189,10 +189,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ButtonGlowHandler.hpp" />
     <ClInclude Include="CustomBlurEffect.hpp" />
     <ClInclude Include="CustomMsstyleLoader.hpp" />
     <ClInclude Include="dwmcoreProjection.hpp" />
     <ClInclude Include="GlassEffectManager.hpp" />
+    <ClInclude Include="GlassSharedStructures.hpp" />
     <ClInclude Include="ReflectionRenderer.hpp" />
     <ClInclude Include="GlassRenderer.hpp" />
     <ClInclude Include="GlassSharedData.hpp" />
@@ -215,6 +217,7 @@
     <ClInclude Include="wil.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ButtonGlowHandler.cpp" />
     <ClCompile Include="CustomBlurEffect.cpp" />
     <ClCompile Include="GlassEffectManager.cpp" />
     <ClCompile Include="VisualManager.cpp" />

--- a/OpenGlass/OpenGlass.vcxproj.user
+++ b/OpenGlass/OpenGlass.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/OpenGlass/Utils.hpp
+++ b/OpenGlass/Utils.hpp
@@ -118,6 +118,24 @@ namespace OpenGlass::Utils
 			static_cast<float>(abgr[3]) / 255.f
 		};
 	}
+	FORCEINLINE D2D1_COLOR_F FromArgb(DWORD color)
+	{
+		auto argb{ reinterpret_cast<const UCHAR*>(&color) };
+		return
+		{
+			static_cast<float>(argb[2]) / 255.f,
+			static_cast<float>(argb[1]) / 255.f,
+			static_cast<float>(argb[0]) / 255.f,
+			static_cast<float>(argb[3]) / 255.f
+		};
+
+		/*
+		float r;
+		float g;
+		float b;
+		float a;
+		*/
+	}
 }
 
 #define DEFINE_INVOKER(fn) static const auto s_fn_ptr{ Utils::cast_pointer<decltype(&fn)>(g_symbolMap.at(#fn)) }

--- a/OpenGlass/VisualManager.cpp
+++ b/OpenGlass/VisualManager.cpp
@@ -175,6 +175,7 @@ HRESULT STDMETHODCALLTYPE VisualManager::CLegacyVisualOverrider::UpdateNCBackgro
 
 	auto color{ m_window->GetTitlebarColorizationParameters()->getArgbcolor() };
 	color.a *= 0.99f;
+	color.r = m_window->TreatAsActiveWindow(); //HACK!!: Send active or inactive window data through the red channel
 	RETURN_IF_FAILED(m_brush->Update(1.0, color));
 
 	wil::unique_hrgn emptyRegion{ CreateRectRgn(0, 0, 0, 0) };

--- a/OpenGlass/VisualManager.cpp
+++ b/OpenGlass/VisualManager.cpp
@@ -2,6 +2,7 @@
 #include "GlassFramework.hpp"
 #include "uDwmProjection.hpp"
 #include "VisualManager.hpp"
+#include "GlassSharedData.hpp"
 #include "Utils.hpp"
 
 using namespace OpenGlass;
@@ -175,7 +176,8 @@ HRESULT STDMETHODCALLTYPE VisualManager::CLegacyVisualOverrider::UpdateNCBackgro
 
 	auto color{ m_window->GetTitlebarColorizationParameters()->getArgbcolor() };
 	color.a *= 0.99f;
-	color.r = m_window->TreatAsActiveWindow(); //HACK!!: Send active or inactive window data through the red channel
+	if (GlassSharedData::g_type == Type::Aero)
+		color.r = m_window->TreatAsActiveWindow(); //HACK!!: Send active or inactive window data through the red channel
 	RETURN_IF_FAILED(m_brush->Update(1.0, color));
 
 	wil::unique_hrgn emptyRegion{ CreateRectRgn(0, 0, 0, 0) };

--- a/OpenGlass/dwmcoreProjection.hpp
+++ b/OpenGlass/dwmcoreProjection.hpp
@@ -475,7 +475,8 @@ namespace OpenGlass::dwmcore
 		CVisual* STDMETHODCALLTYPE GetCurrentVisual() const
 		{
 			DEFINE_INVOKER(CDrawingContext::GetCurrentVisual);
-			return INVOKE_MEMBERFUNCTION();
+			//return INVOKE_MEMBERFUNCTION();
+			return std::invoke(s_fn_ptr, (CDrawingContext*)(__int64(this) + 0x18) );
 		}
 		bool  STDMETHODCALLTYPE IsInLayer() const
 		{

--- a/OpenGlass/dwmcoreProjection.hpp
+++ b/OpenGlass/dwmcoreProjection.hpp
@@ -475,8 +475,8 @@ namespace OpenGlass::dwmcore
 		CVisual* STDMETHODCALLTYPE GetCurrentVisual() const
 		{
 			DEFINE_INVOKER(CDrawingContext::GetCurrentVisual);
-			//return INVOKE_MEMBERFUNCTION();
-			return std::invoke(s_fn_ptr, (CDrawingContext*)(__int64(this) + 0x18) );
+			return INVOKE_MEMBERFUNCTION();
+			//return std::invoke(s_fn_ptr, (CDrawingContext*)(__int64(this) + 0x18) );
 		}
 		bool  STDMETHODCALLTYPE IsInLayer() const
 		{

--- a/OpenGlass/framework.hpp
+++ b/OpenGlass/framework.hpp
@@ -65,11 +65,4 @@
 
 #pragma comment(lib, "onecore.lib")
 
-namespace OpenGlass
-{
-	enum class Type : UCHAR
-	{
-		Blur = 0,
-		Aero = 1
-	};
-}
+

--- a/OpenGlass/framework.hpp
+++ b/OpenGlass/framework.hpp
@@ -64,3 +64,12 @@
 #pragma comment(lib, "dxguid.lib")
 
 #pragma comment(lib, "onecore.lib")
+
+namespace OpenGlass
+{
+	enum class Type : UCHAR
+	{
+		Blur = 0,
+		Aero = 1
+	};
+}

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -604,6 +604,7 @@ namespace OpenGlass::uDwm
 	};
 	struct CTopLevelWindow : CVisual
 	{
+		inline static void*** s_rgpwfWindowFrames{ nullptr };
 		CRgnGeometryProxy* GetBorderGeometry() const
 		{
 			CRgnGeometryProxy* geometry{ nullptr };
@@ -1198,6 +1199,11 @@ namespace OpenGlass::uDwm
 
 			return interopDevice;
 		}
+		HTHEME __fastcall GetTheme(int a1)
+		{
+			DEFINE_INVOKER(CDesktopManager::GetTheme);
+			return INVOKE_MEMBERFUNCTION(a1);
+		}
 	};
 	FORCEINLINE HWND GetShellWindowForCurrentDesktop()
 	{
@@ -1224,6 +1230,7 @@ namespace OpenGlass::uDwm
 		if (
 			fullyUnDecoratedFunctionName.starts_with("CCompositor::") ||
 			fullyUnDecoratedFunctionName.starts_with("CText::") ||
+			fullyUnDecoratedFunctionName.starts_with("CButton::") ||
 			fullyUnDecoratedFunctionName.starts_with("CVisual::") ||
 			fullyUnDecoratedFunctionName.starts_with("CVisualProxy::") ||
 			fullyUnDecoratedFunctionName.starts_with("CCanvasVisual::") ||
@@ -1259,6 +1266,11 @@ namespace OpenGlass::uDwm
 		if (fullyUnDecoratedFunctionName == "CDesktopManager::s_csDwmInstance")
 		{
 			offset.To(g_moduleHandle, CDesktopManager::s_csDwmInstance);
+		}
+		if (fullyUnDecoratedFunctionName == "CTopLevelWindow::s_rgpwfWindowFrames")
+		{
+			uintptr_t address = (offset.value + (uintptr_t)g_moduleHandle);
+			CTopLevelWindow::s_rgpwfWindowFrames = (void***)(address);
 		}
 
 		return true;

--- a/README.md
+++ b/README.md
@@ -2,13 +2,23 @@
 # OpenGlass
 A replica of the dead software glass8, also known as the upstream project of [DWMBlurGlass](https://github.com/Maplespe/DWMBlurGlass).  
 
-This branch does not rely on `dcomp` and `Windows.UI.Composition`, so it is very limited in functionality and it is not unusual to encounter all kinds of bugs, but its performance is much better than the master branch. Currently this branch ONLY supports Windows 10 2004-22H2.
+This branch does not rely on `dcomp` and `Windows.UI.Composition` and instead uses raw Direct2D to leverage better performance than the master branch, however due to it's early nature you may encounter more bugs and crashes. Currently this branch ONLY supports Windows 10 2004-22H2.
 > [!IMPORTANT]  
 > This software is intended for advanced users only. If you are a beginner and you do not have deeper knowledge of Windows (such as registry editing etc.) you should not install this software.  
 > For the average users, you should consider using [DWMBlurGlass](https://github.com/Maplespe/DWMBlurGlass).
 
 > [!WARNING]   
 > OpenGlass does NOT support and is NOT intended to support Windows Insider Preview, so if you want to use it in these Windows versions please do it at your own risk.
+
+## Demonstration
+![Screenshot_1](https://github.com/user-attachments/assets/87bd340e-f60f-427b-83dd-d5470af3628a)
+![Dj2ZNvKO1f](https://github.com/user-attachments/assets/69cb8c6e-1232-4d6a-8661-a8291c1eb40b)
+![BBNq9TdJNM](https://github.com/user-attachments/assets/f2bf46cc-0229-4952-a385-3cfca0df0c35)
+![XzSxjpAIWr](https://github.com/user-attachments/assets/4be75ef3-0862-494a-a4c7-e6679ec2f790)
+![paintdotnet_lRyttWoEq4](https://github.com/user-attachments/assets/9d52fb58-e6b8-438e-8801-28afc19ecdbc)
+> *.msstyles theme used for screenshots: [Aero10 by vaporvance](https://www.deviantart.com/vaporvance/art/Aero10-for-Windows-10-1903-22H2-909711949)*
+
+> *additional software used: [Windhawk](https://windhawk.net/), [Aero Window Manager](https://github.com/Dulappy/aero-window-manager) by @Dulappy*
 ## How to use this software
 1. Extract the files from the Release page to `C:\`, but please don't put them in `C:\Users\*`, otherwise OpenGlass won't work properly.
 2. Run `install.bat` as administrator, this will create a scheduled task for you to run the OpenGlass helper process on boot, which will monitor and automatically inject its component into Dwm.
@@ -26,10 +36,14 @@ The legacy branch can use most of the features of the master branch. The followi
 | master branch | Type | Description | legacy branch | Description | Remarks
 | ---- | ---- | ---- | ---- | ---- | ---- |
 | RoundRectRadius | DWORD | The radius of glass geometry, Win8 = 0, Win7 = 12 |  | Rounded corners are not anti-aliased. | **OK** |
+| og_ColorizationColorBalance | DWORD | Controls the balance of the solid color layer. Behaves the same as Windows 7. |  | **NOTE FOR og_ VARIANTS:** This is done so Windows doesn't override these values with bogus ones. | **OK** |
+| og_ColorizationAfterglowBalance | DWORD | Controls the balance of the multiply+blur layer. Behaves the same as Windows 7. |  |  | **OK** |
+| og_ColorizationrBlurBalance | DWORD | Controls the balance of the blur layer. Behaves the same as Windows 7. |  |  | **OK** |
 | CustomThemeMaterial | String | **Undocumented** |  |  | **Not implemented** |
 | MaterialOpacity | DWORD | **Undocumented** |  |  | **Not implemented** |
 | GlassLuminosity | DWORD | The luminosity of Acrylic/Mica effect |  |  | **Not implemented** |
-| GlassType | DWORD | The type of backdrop effect (0x0-0x4). 0x0=Blur. 0x01=Aero. 0x02=Acrylic. 0x03=Mica. 0x04=Solid. |  | Only 0x0 is implemented. | **OK** |
+| GlassOpacity | DWORD | Controls the opacity of the glass colorization |  | ***TODO:** deprecate this registry key for GlassType 0x1 and introduce an inactive variant for GlassType 0x0 (Vista style) | **OK*** |
+| GlassType | DWORD | The type of backdrop effect (0x0-0x4). 0x0=Blur. 0x01=Aero. 0x02=Acrylic. 0x03=Mica. 0x04=Solid. |  | Only 0x0 and 0x1 are implemented. | **OK** |
 | GlassOverrideBorder | DWORD | Specifies that the effect should extend to the border. The default value is 0. |  | The glass will override the border by default. | **Not implemented** |
 | GlassCrossFadeTime | DWORD | The cross fade time for backdrop switching. The default value is 87. |  |  | **Not supported** |
 | GlassOverrideAccent | DWORD | Overriding accent with the effect of OpenGlass. The default value is 0. |  | Some windows are overwritten resulting in full transparency. And the behavior of the overrides makes a difference. | **OK** |
@@ -70,13 +84,13 @@ PostMessage(FindWindow(TEXT("Dwm"), nullptr), WM_DWMCOLORIZATIONCHANGED, 0, 0); 
         stop AWM  
 
         In this case you are likely to get a crash of DWM or the other software working abnormally.
-- OpenGlass can be used with most windhawk mods, but some may have compatibility issues, especially community or personally written mods that can't be found in the windhawk marketplace.
+- OpenGlass can be used with most Windhawk mods, but some may have compatibility issues, especially community or personally written mods that can't be found in the windhawk marketplace.
 - This branch cannot be used with the master branch.
 
 ## Dependencies and References
 ### [Banner for OpenGlass](https://github.com/ALTaleX531/OpenGlass/discussions/11)
 Provided by [@aubymori](https://github.com/aubymori)  
-Wallpaper: [metalheart jawn](https://www.deviantart.com/kfh83/art/metalheart-jawn-2-1068250045) #2 by [@kfh83](https://github.com/kfh83)
+Wallpaper: [metalheart jawn #2](https://www.deviantart.com/kfh83/art/metalheart-jawn-2-1068250045) by [@kfh83](https://github.com/kfh83)
 ### [Microsoft Research Detours Package](https://github.com/microsoft/Detours)  
 Detours is a software package for monitoring and instrumenting API calls on Windows.  
 ### [VC-LTL - An elegant way to compile lighter binaries.](https://github.com/Chuyu-Team/VC-LTL5)  


### PR DESCRIPTION
With this update, we should get what we once had in DWMBlurGlass (although in my comparisons it's actually even more accurate), but with the performance of raw D2D. We've performance tested this quite a bit on low end machines and the impact is minimal, so expect great performance while getting the looks. Additionally for those who use SIB, this COMPLETELY overrides colorization anywhere it touches, so everything is synced, you can even set the SIB custom color to completely clear and somewhat fix jumplists/previews' colorization. Below are some demonstration images (that i've also added to README.MD):

![XzSxjpAIWr](https://github.com/user-attachments/assets/2a22f983-a57d-4d24-b2dd-459a704cdb99)
![BBNq9TdJNM](https://github.com/user-attachments/assets/32e5b081-ae1e-4b76-9680-725fd511e07e)
![Dj2ZNvKO1f](https://github.com/user-attachments/assets/13f46b5a-5369-4a37-b7af-a4656cff7c70)
![paintdotnet_lRyttWoEq4](https://github.com/user-attachments/assets/737f9898-e782-42b7-9d93-f8dfba3597c8)
![image](https://github.com/user-attachments/assets/8a829609-b7c2-4d8a-b93f-8b550f6e43f2)


Thanks a lot to @wiktorwiktor12 for immense help on this, and to the ones who have helped in the past in the DWMBlurGlass shader, either with research or with code help. (some of you have been added in credits to the code)

## NOTE:
As a suggestion more than anything, i think region splitting should be added to a toggle in similar fashion to what we had a while ago in the master branch. Splitting causes a bit of ugliness in the titlebar/border merge area:
![image](https://github.com/user-attachments/assets/24deecaf-0a7d-4dff-a3e6-8e1ae098a9f0)

## BUGS/THINGS LEFT OUT:
Windows are completely clear when opening/closing, and seem to retain their backdrop when restoring from minimized/ minimizing. Not sure if this was a bug already with the legacy branch, but regardless it happens here:
![image](https://github.com/user-attachments/assets/940ffb53-654b-4e65-bc53-31c7f6276061)

Old windows glitch out entirely if you switch from GlassType 0x0 to 0x1 (and vice versa) at runtime. Make sure to restart OpenGlass entirely if you plan on doing that.

I would also have liked to deprecate GlassOpacity for GlassType 0x1, and have kept it for 0x0 with an inactive variant as a way of doing Vista colorization.

And for those who wish to test this out before it gets merged, heres a binary. Make sure to add
`og_ColorizationColorBalance`, `og_ColorizationAfterglowBalance` and `og_ColorizationBlurBalance`to `HKCU\SOFTWARE\Microsoft\Windows\DWM` to control the colorization balances. Values are the same as Windows 7. 
[OpenGlass.dll.zip](https://github.com/user-attachments/files/16277347/OpenGlass.dll.zip)

We've decided to make new keys instead of re-using the existing ones provided by Windows because these keys get set to bogus values by Windows (typically at logon) and they don't really have a way of getting set anyways besides going to the registry and setting them there, so we decided to cut the hassle and made these separate. We plan on hooking to the glass color cpl page to see if we can restore functionality to the intensity slider, hopefully so you dont have to go to the registry anymore for this.

