### PR TITLE
Fix aero peek clone behaviour

### DIFF
--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -19,8 +19,39 @@ namespace OpenGlass::ButtonGlowHandler
 	static int CLOSEBUTTONGLOW = 92; //11 in windows 7
 	static int TOOLCLOSEBUTTONGLOW = 94; //47 in windows 7
 
+	bool UpdateCrossfade{ false };
+
+	void STDMETHODCALLTYPE CVisual_SetDirtyFlags_hook(uDWM::CVisual* This, int flags);
+	void STDMETHODCALLTYPE CButton_UpdateCrossfade_hook(uDWM::CButton* This);
+
+	decltype(&CVisual_SetDirtyFlags_hook) CVisual_SetDirtyFlags_orig{ nullptr };
+	decltype(&CButton_UpdateCrossfade_hook) CButton_UpdateCrossfade_orig{ nullptr };
+
+
 	HRESULT(WINAPI* CTopLevelWindow__CreateBitmapFromAtlas)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
 	
+	void STDMETHODCALLTYPE CButton_UpdateCrossfade_hook(uDWM::CButton* This)
+	{
+		UpdateCrossfade = true;
+		CButton_UpdateCrossfade_orig(This);
+		UpdateCrossfade = false;
+	}
+
+	void STDMETHODCALLTYPE CVisual_SetDirtyFlags_hook(uDWM::CVisual* This, int flags)
+	{
+		// workaround for button glow cutoff
+		if (UpdateCrossfade)
+		{
+			uDWM::CButton* button = reinterpret_cast<uDWM::CButton*>(This);
+			if (flags == 0x8000 && *button->GetButtonState() == 3)
+			{
+				return;
+			}
+		}
+
+		CVisual_SetDirtyFlags_orig(This, flags);
+	}
+
 	//not 1 to 1 to the one in windows 7 udwm, however it achieves the same outcome whilst being simpler
 	HRESULT CTopLevelWindow__CreateButtonGlowsFromAtlas(HTHEME hTheme)
 	{
@@ -71,13 +102,17 @@ namespace OpenGlass::ButtonGlowHandler
 	{
 		if (uDWM::g_buildNumber < os::build_w11_21h2)
 		{
+			uDWM::g_projectionArray.ApplyToVariable("CVisual::SetDirtyFlags", CVisual_SetDirtyFlags_orig);
 			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateBitmapFromAtlas", CTopLevelWindow__CreateBitmapFromAtlas);
 			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateGlyphsFromAtlas", CTopLevelWindow_CreateGlyphsFromAtlas);
+			uDWM::g_projectionArray.ApplyToVariable("CButton::UpdateCrossfade", CButton_UpdateCrossfade_orig);
 
 			THROW_IF_FAILED(
 				HookHelper::Detours::Write([]()
 				{
+					HookHelper::Detours::Attach(&CVisual_SetDirtyFlags_orig, CVisual_SetDirtyFlags_hook);
 					HookHelper::Detours::Attach(&CTopLevelWindow_CreateGlyphsFromAtlas, CTopLevelWindow_CreateGlyphsFromAtlas_Hook);
+					HookHelper::Detours::Attach(&CButton_UpdateCrossfade_orig, CButton_UpdateCrossfade_hook);
 				})
 			);
 		}
@@ -90,7 +125,9 @@ namespace OpenGlass::ButtonGlowHandler
 			THROW_IF_FAILED(
 				HookHelper::Detours::Write([]()
 				{
+					HookHelper::Detours::Detach(&CVisual_SetDirtyFlags_orig, CVisual_SetDirtyFlags_hook);
 					HookHelper::Detours::Detach(&CTopLevelWindow_CreateGlyphsFromAtlas, CTopLevelWindow_CreateGlyphsFromAtlas_Hook);
+					HookHelper::Detours::Detach(&CButton_UpdateCrossfade_orig, CButton_UpdateCrossfade_hook);
 				})
 			);
 		}

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -16,8 +16,12 @@ namespace OpenGlass::GlassFrameHandler
 
 	HRESULT STDMETHODCALLTYPE MyResourceHelper_CreateGeometryFromHRGN(HRGN hrgn, uDWM::CRgnGeometryProxy** geometry);
 	HRESULT STDMETHODCALLTYPE MyCSolidColorLegacyMilBrushProxy_Update(uDWM::CSolidColorLegacyMilBrushProxy* This, double opacity, const D2D1_COLOR_F& color);
+	bool STDMETHODCALLTYPE MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage(uDWM::CTopLevelAtlasedRectsVisual* This, const uDWM::CAtlasedImage* atlasedImage, UINT cloneOptions);
+	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10(uDWM::CTopLevelWindow* This, bool windowFramesOnly, bool unused1, bool unused2, uDWM::CTopLevelWindow** clonedWindow);
+	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11(uDWM::CTopLevelWindow* This, bool windowFramesOnly, uDWM::CTopLevelWindow** clonedWindow);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_UpdateNCAreaBackground(uDWM::CTopLevelWindow* This);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_UpdateClientBlur(uDWM::CTopLevelWindow* This);
+	HRESULT STDMETHODCALLTYPE MyCButton_CloneVisualTree(uDWM::CButton* This, uDWM::CButton** clonedVisual, UINT cloneOption);
 	void STDMETHODCALLTYPE MyCButton_SetSize(uDWM::CButton* This, const SIZE* size);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_ValidateVisual(uDWM::CTopLevelWindow* This);
 	bool WINAPI MySetMargin(
@@ -29,15 +33,25 @@ namespace OpenGlass::GlassFrameHandler
 		const MARGINS* srcMargins
 	);
 
+	HRESULT(STDMETHODCALLTYPE* CVisual_RenderRecursive)(uDWM::CVisual* visual);
+	HRESULT(STDMETHODCALLTYPE* CButton_Create)(uDWM::CButton** outButton);
+	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, uDWM::CBitmapSource* glowBitmap, float opacity);
+	HRESULT(STDMETHODCALLTYPE* CAtlasedRectsVisual_InitializeVisualTreeClone)(uDWM::CAtlasedRectsVisual* This, uDWM::CAtlasedRectsVisual* clonedVisual, UINT cloneOption);
+
 	decltype(&MyCreateRoundRectRgn) g_CreateRoundRectRgn_Org{ nullptr };
 	decltype(&MyCreateRectRgn) g_CreateRectRgn_Org{ nullptr };
 	decltype(&MyExtCreateRegion) g_ExtCreateRegion_Org{ nullptr };
 
 	decltype(&MyResourceHelper_CreateGeometryFromHRGN) g_ResourceHelper_CreateGeometryFromHRGN_Org{ nullptr };
 	decltype(&MyCSolidColorLegacyMilBrushProxy_Update) g_CSolidColorLegacyMilBrushProxy_Update_Org{ nullptr };
+	decltype(&MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage) g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org{ nullptr };
+	decltype(&MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10) g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org{ nullptr };
+	decltype(&MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11) g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_UpdateNCAreaBackground) g_CTopLevelWindow_UpdateNCAreaBackground_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_UpdateClientBlur) g_CTopLevelWindow_UpdateClientBlur_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_ValidateVisual) g_CTopLevelWindow_ValidateVisual_Org{ nullptr };
+	decltype(&MyCButton_CloneVisualTree) g_CButton_CloneVisualTree_Org{ nullptr };
+	decltype(&MyCButton_CloneVisualTree)* g_CButton_CloneVisualTree_Org_Address{ nullptr };
 	decltype(&MyCButton_SetSize) g_CButton_SetSize_Org{ nullptr };
 	decltype(&MyCButton_SetSize)* g_CButton_SetSize_Org_Address{ nullptr };
 	decltype(&MySetMargin) g_SetMargin_Org{ nullptr };
@@ -106,6 +120,8 @@ namespace OpenGlass::GlassFrameHandler
 	bool g_systemBackdrop{ false };
 	std::optional<bool> g_redirectFirstCreateRectRgnCall{};
 	bool g_blockUpdatingSolidColorBrush{ false };
+	bool g_CloneVisualForLivePreview{ false };
+	bool g_windowFramesOnly{ false };
 }
 
 HRGN WINAPI GlassFrameHandler::MyCreateRoundRectRgn(int x1, int y1, int x2, int y2, int w, int h)
@@ -224,6 +240,72 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCSolidColorLegacyMilBrushProxy_Up
 		opacity,
 		color
 	);
+}
+
+bool STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage(uDWM::CTopLevelAtlasedRectsVisual* This, const uDWM::CAtlasedImage* atlasedImage, UINT cloneOptions)
+{
+	const auto partId = atlasedImage->GetPartId();
+
+	bool isSqueegeePart = (partId - 9) <= 8;
+	bool isButtonPart = (partId == 22);
+	bool isWindowPart = (partId) <= 7;
+
+	// hide button image
+	if (isButtonPart && uDWM::g_buildNumber != os::build_w11_21h2)
+	{
+		return 0;
+	}
+
+	// hide live preview images in close/minimize animation and focused live preview window
+	if ((isSqueegeePart && !g_CloneVisualForLivePreview) || (isSqueegeePart && g_CloneVisualForLivePreview && !g_windowFramesOnly))
+	{
+		return 0;
+	}
+
+	// show window frames in focused live preview window
+	if (isWindowPart && g_CloneVisualForLivePreview && !g_windowFramesOnly)
+	{
+		return 1;
+	}
+
+	return g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org(This, atlasedImage, cloneOptions);
+}
+
+HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10(uDWM::CTopLevelWindow* This, bool windowFramesOnly, bool unused1, bool unused2, uDWM::CTopLevelWindow** clonedWindow)
+{
+	g_CloneVisualForLivePreview = true;
+	g_windowFramesOnly = windowFramesOnly;
+	auto hr = g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org(This, windowFramesOnly, unused1, unused2, clonedWindow);
+	g_CloneVisualForLivePreview = false;
+	g_windowFramesOnly = !windowFramesOnly;
+
+	for (int i = 0; i < 4; i++)
+	{
+		if (auto button = This->GetButton(i))
+		{
+			// HACK: we need to allow the cloning of buttons after this function for close/minimize
+			if (uDWM::g_buildNumber < os::build_w11_21h2)
+			{
+				if (*button->IsCloneAllowed() == 12)
+				{
+					*button->IsCloneAllowed() = 4;
+				}
+			}
+		}
+	}
+
+	return hr;
+}
+
+HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11(uDWM::CTopLevelWindow* This, bool windowFramesOnly, uDWM::CTopLevelWindow** clonedWindow)
+{
+	g_CloneVisualForLivePreview = true;
+	g_windowFramesOnly = windowFramesOnly;
+	auto hr = g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org(This, windowFramesOnly, clonedWindow);
+	g_CloneVisualForLivePreview = false;
+	g_windowFramesOnly = !windowFramesOnly;
+
+	return hr;
 }
 
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaBackground(uDWM::CTopLevelWindow* This)
@@ -385,6 +467,33 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateClientBlur(
 	return hr;
 }
 
+HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCButton_CloneVisualTree(uDWM::CButton* This, uDWM::CButton** clonedVisual, UINT cloneOption)
+{
+	auto cleanup = wil::scope_exit([clonedVisual]
+		{
+			if (clonedVisual)
+			{
+				(*clonedVisual)->Release();
+				*clonedVisual = nullptr;
+			}
+		});
+
+		// CButton::CancelCrossfade
+		if (This->GetTimeline())
+		{
+			*This->GetButtonState() |= 0x40u;
+			This->SetDirtyFlags(0x10000);
+			RETURN_IF_FAILED(CVisual_RenderRecursive(This));
+		}
+
+		RETURN_IF_FAILED(CButton_Create(clonedVisual));
+		RETURN_IF_FAILED(CAtlasedRectsVisual_InitializeVisualTreeClone(This, *clonedVisual, cloneOption));
+		RETURN_IF_FAILED(CButton_SetVisualStates(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), nullptr, This->GetGlyphOpacity()));
+		cleanup.release();
+
+		return S_OK;
+}
+
 void STDMETHODCALLTYPE GlassFrameHandler::MyCButton_SetSize(uDWM::CButton* This, const SIZE* size)
 {
 	if (Shared::g_captionHeight.has_value())
@@ -526,21 +635,47 @@ void GlassFrameHandler::Startup()
 {
 	uDWM::g_projectionArray.ApplyToVariable("ResourceHelper::CreateGeometryFromHRGN", g_ResourceHelper_CreateGeometryFromHRGN_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CSolidColorLegacyMilBrushProxy::Update", g_CSolidColorLegacyMilBrushProxy_Update_Org);
+	uDWM::g_projectionArray.ApplyToVariable("CTopLevelAtlasedRectsVisual::ShouldCloneAtlasImage", g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateNCAreaBackground", g_CTopLevelWindow_UpdateNCAreaBackground_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateClientBlur", g_CTopLevelWindow_UpdateClientBlur_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::ValidateVisual", g_CTopLevelWindow_ValidateVisual_Org);
 	uDWM::g_projectionArray.ApplyToVariable("SetMargin", g_SetMargin_Org);
 	
 	PVOID CVisual_SetSize_Org{ nullptr };
+	PVOID CAtlasedRectsVisual_CloneVisualTree_Org{ nullptr };
 	uDWM::g_projectionArray.ApplyToVariable("CVisual::SetSize", CVisual_SetSize_Org);
-	for (auto& vf : std::span{ uDWM::CButton::vftable, 16 })
+	uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::CloneVisualTree", CAtlasedRectsVisual_CloneVisualTree_Org);
+	for (auto& vf : std::span{ uDWM::CButton::vftable, 20 })
 	{
 		if (vf == CVisual_SetSize_Org)
 		{
 			g_CButton_SetSize_Org_Address = reinterpret_cast<decltype(g_CButton_SetSize_Org_Address)>(&vf);
 			g_CButton_SetSize_Org = HookHelper::WritePointer(g_CButton_SetSize_Org_Address, MyCButton_SetSize);
 		}
+		if (vf == CAtlasedRectsVisual_CloneVisualTree_Org && uDWM::g_buildNumber < os::build_w11_21h2)
+		{
+			g_CButton_CloneVisualTree_Org_Address = reinterpret_cast<decltype(g_CButton_CloneVisualTree_Org_Address)>(&vf);
+			g_CButton_CloneVisualTree_Org = HookHelper::WritePointer(g_CButton_CloneVisualTree_Org_Address, MyCButton_CloneVisualTree);
+		}
 	}
+
+	if (uDWM::g_buildNumber < os::build_w11_21h2)
+	{
+		uDWM::g_projectionArray.ApplyToVariable("CVisual::RenderRecursive", CVisual_RenderRecursive);
+		uDWM::g_projectionArray.ApplyToVariable("CButton::Create", CButton_Create);
+		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates);
+		uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::InitializeVisualTreeClone", CAtlasedRectsVisual_InitializeVisualTreeClone);
+	}
+	
+	if (uDWM::g_buildNumber <= os::build_w11_21h2)
+	{
+		uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CloneVisualTreeForLivePreview", g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org);
+	}
+	else
+	{
+		uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CloneVisualTreeForLivePreview", g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org);
+	}
+
 
 	if (uDWM::g_buildNumber >= os::build_w11_21h2)
 	{
@@ -684,9 +819,19 @@ void GlassFrameHandler::Startup()
 		{
 			HookHelper::Detours::Attach(&g_ResourceHelper_CreateGeometryFromHRGN_Org, MyResourceHelper_CreateGeometryFromHRGN);
 			HookHelper::Detours::Attach(&g_CSolidColorLegacyMilBrushProxy_Update_Org, MyCSolidColorLegacyMilBrushProxy_Update);
+			HookHelper::Detours::Attach(&g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org, MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage);
 			HookHelper::Detours::Attach(&g_CTopLevelWindow_UpdateNCAreaBackground_Org, MyCTopLevelWindow_UpdateNCAreaBackground);
 			HookHelper::Detours::Attach(&g_CTopLevelWindow_UpdateClientBlur_Org, MyCTopLevelWindow_UpdateClientBlur);
 			
+			if (uDWM::g_buildNumber <= os::build_w11_21h2)
+			{
+				HookHelper::Detours::Attach(&g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org, MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10);
+			}
+			else
+			{
+				HookHelper::Detours::Attach(&g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org, MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11);
+			}
+
 			if (uDWM::g_buildNumber >= os::build_w11_21h2)
 			{
 				HookHelper::Detours::Attach(&g_CTopLevelWindow_ValidateVisual_Org, MyCTopLevelWindow_ValidateVisual);
@@ -703,8 +848,18 @@ void GlassFrameHandler::Shutdown()
 		{
 			HookHelper::Detours::Detach(&g_ResourceHelper_CreateGeometryFromHRGN_Org, MyResourceHelper_CreateGeometryFromHRGN);
 			HookHelper::Detours::Detach(&g_CSolidColorLegacyMilBrushProxy_Update_Org, MyCSolidColorLegacyMilBrushProxy_Update);
+			HookHelper::Detours::Detach(&g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org, MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_UpdateNCAreaBackground_Org, MyCTopLevelWindow_UpdateNCAreaBackground);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_UpdateClientBlur_Org, MyCTopLevelWindow_UpdateClientBlur);
+
+			if (uDWM::g_buildNumber <= os::build_w11_21h2)
+			{
+				HookHelper::Detours::Detach(&g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org, MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10);
+			}
+			else
+			{
+				HookHelper::Detours::Detach(&g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org, MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11);
+			}
 
 			if (uDWM::g_buildNumber >= os::build_w11_21h2)
 			{
@@ -729,6 +884,10 @@ void GlassFrameHandler::Shutdown()
 	if (g_CButton_SetSize_Org)
 	{
 		HookHelper::WritePointer(g_CButton_SetSize_Org_Address, g_CButton_SetSize_Org);
+	}
+	if (g_CButton_CloneVisualTree_Org)
+	{
+		HookHelper::WritePointer(g_CButton_CloneVisualTree_Org_Address, g_CButton_CloneVisualTree_Org);
 	}
 
 	g_combinedRgn.reset();

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -33,11 +33,6 @@ namespace OpenGlass::GlassFrameHandler
 		const MARGINS* srcMargins
 	);
 
-	HRESULT(STDMETHODCALLTYPE* CButton_Create)(uDWM::CButton** outButton);
-	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates_Win10)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, uDWM::CBitmapSource* glowBitmap, float opacity);
-	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates_Win11)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, float opacity);
-	HRESULT(STDMETHODCALLTYPE* CAtlasedRectsVisual_InitializeVisualTreeClone)(uDWM::CAtlasedRectsVisual* This, uDWM::CAtlasedRectsVisual* clonedVisual, UINT cloneOption);
-
 	decltype(&MyCreateRoundRectRgn) g_CreateRoundRectRgn_Org{ nullptr };
 	decltype(&MyCreateRectRgn) g_CreateRectRgn_Org{ nullptr };
 	decltype(&MyExtCreateRegion) g_ExtCreateRegion_Org{ nullptr };
@@ -120,7 +115,6 @@ namespace OpenGlass::GlassFrameHandler
 	bool g_systemBackdrop{ false };
 	std::optional<bool> g_redirectFirstCreateRectRgnCall{};
 	bool g_blockUpdatingSolidColorBrush{ false };
-	bool g_CloneVisualForLivePreview{ false };
 	bool g_windowFramesOnly{ false };
 }
 
@@ -253,19 +247,19 @@ bool STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelAtlasedRectsVisual_ShouldCl
 	// hide button image
 	if (isButtonPart)
 	{
-		return 0;
+		return false;
 	}
 
 	// hide live preview images in close/minimize animation and focused live preview window
-	if ((isSqueegeePart && !g_CloneVisualForLivePreview) || (isSqueegeePart && g_CloneVisualForLivePreview && !g_windowFramesOnly))
+	if ((isSqueegeePart && (cloneOptions == 4)) || (isSqueegeePart && (cloneOptions != 4) && !g_windowFramesOnly))
 	{
-		return 0;
+		return false;
 	}
 
 	// show window frames in focused live preview window
-	if (isWindowPart && g_CloneVisualForLivePreview && !g_windowFramesOnly)
+	if (isWindowPart && (cloneOptions != 4) && !g_windowFramesOnly)
 	{
-		return 1;
+		return true;
 	}
 
 	return g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org(This, atlasedImage, cloneOptions);
@@ -273,10 +267,8 @@ bool STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelAtlasedRectsVisual_ShouldCl
 
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10(uDWM::CTopLevelWindow* This, bool windowFramesOnly, bool unused1, bool unused2, uDWM::CTopLevelWindow** clonedWindow)
 {
-	g_CloneVisualForLivePreview = true;
 	g_windowFramesOnly = windowFramesOnly;
 	auto hr = g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org(This, windowFramesOnly, unused1, unused2, clonedWindow);
-	g_CloneVisualForLivePreview = false;
 	g_windowFramesOnly = !windowFramesOnly;
 
 	for (int i = 0; i < 4; i++)
@@ -286,10 +278,7 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeFo
 			// HACK: we need to allow the cloning of buttons after this function for close/minimize
 			if (uDWM::g_buildNumber < os::build_w11_21h2)
 			{
-				if (*button->IsCloneAllowed() == 12)
-				{
-					*button->IsCloneAllowed() = 4;
-				}
+				button->SetExcludeSubtree(false);
 			}
 		}
 	}
@@ -299,10 +288,8 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeFo
 
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11(uDWM::CTopLevelWindow* This, bool windowFramesOnly, uDWM::CTopLevelWindow** clonedWindow)
 {
-	g_CloneVisualForLivePreview = true;
 	g_windowFramesOnly = windowFramesOnly;
 	auto hr = g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org(This, windowFramesOnly, clonedWindow);
-	g_CloneVisualForLivePreview = false;
 	g_windowFramesOnly = !windowFramesOnly;
 
 	return hr;
@@ -470,38 +457,36 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateClientBlur(
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCButton_CloneVisualTree(uDWM::CButton* This, uDWM::CButton** clonedVisual, UINT cloneOption)
 {
 	auto cleanup = wil::scope_exit([clonedVisual]
+	{
+		if (clonedVisual)
 		{
-			if (clonedVisual)
-			{
-				(*clonedVisual)->Release();
-				*clonedVisual = nullptr;
-			}
-		});
-
-		// CButton::CancelCrossfade
-		if (This->GetTimeline())
-		{
-			*This->GetButtonState() |= 0x40u;
-			This->SetDirtyFlags(0x10000);
-			RETURN_IF_FAILED(This->RenderRecursive());
+			(*clonedVisual)->Release();
+			*clonedVisual = nullptr;
 		}
+	});
 
-		RETURN_IF_FAILED(CButton_Create(clonedVisual));
-		RETURN_IF_FAILED(CAtlasedRectsVisual_InitializeVisualTreeClone(This, *clonedVisual, cloneOption));
-		
-		if (uDWM::g_buildNumber < os::build_w11_21h2)
-		{
-			RETURN_IF_FAILED(CButton_SetVisualStates_Win10(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), nullptr, This->GetGlyphOpacity()));
-		}
-		else
-		{
-			RETURN_IF_FAILED(CButton_SetVisualStates_Win11(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), This->GetGlyphOpacity()));
-		}
+	// CButton::CancelCrossfade
+	if (This->GetTimeline())
+	{
+		*This->GetButtonState() |= 0x40u;
+		This->SetDirtyFlags(0x10000);
+		RETURN_IF_FAILED(This->RenderRecursive());
+	}
 
-		*(*clonedVisual)->GetButtonState() = *This->GetButtonState();
-		cleanup.release();
+	RETURN_IF_FAILED(uDWM::CButton::Create(clonedVisual));
+	RETURN_IF_FAILED(This->InitializeVisualTreeClone(*clonedVisual, cloneOption));
+	RETURN_IF_FAILED(
+		(*clonedVisual)->SetVisualStates(
+			This->GetGlyphBitmapArray(),
+			This->GetButtonBitmapArray(),
+			This->GetGlyphOpacity()
+		)
+	);
 
-		return S_OK;
+	*(*clonedVisual)->GetButtonState() = *This->GetButtonState();
+	cleanup.release();
+
+	return S_OK;
 }
 
 void STDMETHODCALLTYPE GlassFrameHandler::MyCButton_SetSize(uDWM::CButton* This, const SIZE* size)
@@ -668,21 +653,10 @@ void GlassFrameHandler::Startup()
 			g_CButton_CloneVisualTree_Org = HookHelper::WritePointer(g_CButton_CloneVisualTree_Org_Address, MyCButton_CloneVisualTree);
 		}
 	}
-
-	if (uDWM::g_buildNumber < os::build_w11_21h2)
-	{
-		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates_Win10);
-	}
-	else
-	{
-		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates_Win11);
-	}
 	
 	if (uDWM::g_buildNumber <= os::build_w11_21h2)
 	{
 		uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CloneVisualTreeForLivePreview", g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org);
-		uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::InitializeVisualTreeClone", CAtlasedRectsVisual_InitializeVisualTreeClone);
-		uDWM::g_projectionArray.ApplyToVariable("CButton::Create", CButton_Create);
 	}
 	else
 	{

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -489,6 +489,7 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCButton_CloneVisualTree(uDWM::CBu
 		RETURN_IF_FAILED(CButton_Create(clonedVisual));
 		RETURN_IF_FAILED(CAtlasedRectsVisual_InitializeVisualTreeClone(This, *clonedVisual, cloneOption));
 		RETURN_IF_FAILED(CButton_SetVisualStates(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), nullptr, This->GetGlyphOpacity()));
+		*(*clonedVisual)->GetButtonState() = *This->GetButtonState();
 		cleanup.release();
 
 		return S_OK;

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -33,9 +33,9 @@ namespace OpenGlass::GlassFrameHandler
 		const MARGINS* srcMargins
 	);
 
-	HRESULT(STDMETHODCALLTYPE* CVisual_RenderRecursive)(uDWM::CVisual* visual);
 	HRESULT(STDMETHODCALLTYPE* CButton_Create)(uDWM::CButton** outButton);
-	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, uDWM::CBitmapSource* glowBitmap, float opacity);
+	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates_Win10)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, uDWM::CBitmapSource* glowBitmap, float opacity);
+	HRESULT(STDMETHODCALLTYPE* CButton_SetVisualStates_Win11)(uDWM::CButton* This, uDWM::CBitmapSourceArray* buttonArray, uDWM::CBitmapSourceArray* glyphArray, float opacity);
 	HRESULT(STDMETHODCALLTYPE* CAtlasedRectsVisual_InitializeVisualTreeClone)(uDWM::CAtlasedRectsVisual* This, uDWM::CAtlasedRectsVisual* clonedVisual, UINT cloneOption);
 
 	decltype(&MyCreateRoundRectRgn) g_CreateRoundRectRgn_Org{ nullptr };
@@ -251,7 +251,7 @@ bool STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelAtlasedRectsVisual_ShouldCl
 	bool isWindowPart = (partId) <= 7;
 
 	// hide button image
-	if (isButtonPart && uDWM::g_buildNumber != os::build_w11_21h2)
+	if (isButtonPart)
 	{
 		return 0;
 	}
@@ -483,12 +483,21 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCButton_CloneVisualTree(uDWM::CBu
 		{
 			*This->GetButtonState() |= 0x40u;
 			This->SetDirtyFlags(0x10000);
-			RETURN_IF_FAILED(CVisual_RenderRecursive(This));
+			RETURN_IF_FAILED(This->RenderRecursive());
 		}
 
 		RETURN_IF_FAILED(CButton_Create(clonedVisual));
 		RETURN_IF_FAILED(CAtlasedRectsVisual_InitializeVisualTreeClone(This, *clonedVisual, cloneOption));
-		RETURN_IF_FAILED(CButton_SetVisualStates(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), nullptr, This->GetGlyphOpacity()));
+		
+		if (uDWM::g_buildNumber < os::build_w11_21h2)
+		{
+			RETURN_IF_FAILED(CButton_SetVisualStates_Win10(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), nullptr, This->GetGlyphOpacity()));
+		}
+		else
+		{
+			RETURN_IF_FAILED(CButton_SetVisualStates_Win11(*clonedVisual, This->GetGlyphBitmapArray(), This->GetButtonBitmapArray(), This->GetGlyphOpacity()));
+		}
+
 		*(*clonedVisual)->GetButtonState() = *This->GetButtonState();
 		cleanup.release();
 
@@ -653,7 +662,7 @@ void GlassFrameHandler::Startup()
 			g_CButton_SetSize_Org_Address = reinterpret_cast<decltype(g_CButton_SetSize_Org_Address)>(&vf);
 			g_CButton_SetSize_Org = HookHelper::WritePointer(g_CButton_SetSize_Org_Address, MyCButton_SetSize);
 		}
-		if (vf == CAtlasedRectsVisual_CloneVisualTree_Org && uDWM::g_buildNumber < os::build_w11_21h2)
+		if (vf == CAtlasedRectsVisual_CloneVisualTree_Org && uDWM::g_buildNumber <= os::build_w11_21h2)
 		{
 			g_CButton_CloneVisualTree_Org_Address = reinterpret_cast<decltype(g_CButton_CloneVisualTree_Org_Address)>(&vf);
 			g_CButton_CloneVisualTree_Org = HookHelper::WritePointer(g_CButton_CloneVisualTree_Org_Address, MyCButton_CloneVisualTree);
@@ -662,15 +671,18 @@ void GlassFrameHandler::Startup()
 
 	if (uDWM::g_buildNumber < os::build_w11_21h2)
 	{
-		uDWM::g_projectionArray.ApplyToVariable("CVisual::RenderRecursive", CVisual_RenderRecursive);
-		uDWM::g_projectionArray.ApplyToVariable("CButton::Create", CButton_Create);
-		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates);
-		uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::InitializeVisualTreeClone", CAtlasedRectsVisual_InitializeVisualTreeClone);
+		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates_Win10);
+	}
+	else
+	{
+		uDWM::g_projectionArray.ApplyToVariable("CButton::SetVisualStates", CButton_SetVisualStates_Win11);
 	}
 	
 	if (uDWM::g_buildNumber <= os::build_w11_21h2)
 	{
 		uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CloneVisualTreeForLivePreview", g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org);
+		uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::InitializeVisualTreeClone", CAtlasedRectsVisual_InitializeVisualTreeClone);
+		uDWM::g_projectionArray.ApplyToVariable("CButton::Create", CButton_Create);
 	}
 	else
 	{

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -187,20 +187,27 @@ namespace OpenGlass::uDWM
 			}
 			return pt;
 		}
-		BYTE* IsCloneAllowed()
+		void SetExcludeSubtree(bool exclude)
 		{
-			BYTE* cloneAllowed{ nullptr };
+			BYTE* properties{ nullptr };
 
 			if (g_buildNumber < os::build_w11_21h2)
 			{
-				cloneAllowed = &(reinterpret_cast<BYTE*>(this)[84]);
+				properties = &(reinterpret_cast<BYTE*>(this)[84]);
 			}
 			else
 			{
-				cloneAllowed = &(reinterpret_cast<BYTE*>(this)[92]);
+				properties = &(reinterpret_cast<BYTE*>(this)[92]);
 			}
 
-			return cloneAllowed;
+			if (exclude)
+			{
+				*properties |= 8;
+			}
+			else
+			{
+				*properties &= ~8;
+			}
 		}
 		VisualCollection* GetVisualCollection()
 		{
@@ -430,12 +437,21 @@ namespace OpenGlass::uDWM
 		}
 	};
 
-	struct CBitmapSource {};
+	struct CBitmapSource : CBaseObject {};
 	struct CBitmapSourceArray : DynArray<CBitmapSource*> {};
 
-	struct CAtlasedRectsVisual : CVisual {};
+	struct CAtlasedRectsVisual : CVisual 
+	{
+		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE InitializeVisualTreeClone(
+			CAtlasedRectsVisual* clonedVisual, 
+			UINT cloneOption
+		)
+		{
+			return HANDLE_PROJECTION_FUNCTION(CAtlasedRectsVisual::InitializeVisualTreeClone, clonedVisual, cloneOption);
+		}
+	};
 	struct CTopLevelAtlasedRectsVisual : CAtlasedRectsVisual {};
-	struct CAtlasedImage
+	struct CAtlasedImage : CBaseObject
 	{
 		DWORD GetPartId() const
 		{
@@ -447,6 +463,63 @@ namespace OpenGlass::uDWM
 	struct CButton : CAtlasedRectsVisual
 	{
 		inline static PVOID* vftable{ nullptr };
+
+		DECLSPEC_PROJECTION static HRESULT STDMETHODCALLTYPE Create(CButton** visual)
+		{
+			return HANDLE_PROJECTION_FUNCTION(CButton::Create, visual);
+		}
+		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE SetVisualStates_Win10(
+			uDWM::CBitmapSourceArray* buttonArray, 
+			uDWM::CBitmapSourceArray* glyphArray, 
+			uDWM::CBitmapSource* glowBitmap, 
+			float opacity
+		)
+		{
+			return HANDLE_PROJECTION_FUNCTION(
+				CButton::SetVisualStates_Win10,
+				buttonArray,
+				glyphArray,
+				glowBitmap,
+				opacity
+			);
+		}
+		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE SetVisualStates_Win11(
+			uDWM::CBitmapSourceArray* buttonArray,
+			uDWM::CBitmapSourceArray* glyphArray,
+			float opacity
+		)
+		{
+			return HANDLE_PROJECTION_FUNCTION(
+				CButton::SetVisualStates_Win11,
+				buttonArray,
+				glyphArray,
+				opacity
+			);
+		}
+		HRESULT STDMETHODCALLTYPE SetVisualStates(
+			uDWM::CBitmapSourceArray* buttonArray,
+			uDWM::CBitmapSourceArray* glyphArray,
+			float opacity
+		)
+		{
+			if (g_buildNumber < os::build_w11_22h2) [[likely]]
+			{
+				return SetVisualStates_Win10(
+					buttonArray,
+					glyphArray,
+					nullptr,
+					opacity
+				);
+			}
+			else
+			{
+				return SetVisualStates_Win11(
+					buttonArray,
+					glyphArray,
+					opacity
+				);
+			}
+		}
 
 		float GetGlyphOpacity()
 		{
@@ -1874,11 +1947,12 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CText::`scalar deleting destructor'", 0, os::build_w11_22h2),
 
 		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::CloneVisualTree", 0, os::build_w11_22h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::InitializeVisualTreeClone", 0, os::build_w11_22h2),
+		MAKE_FUNCTION_PROJECTION_TUPLE(CAtlasedRectsVisual::InitializeVisualTreeClone, 0, os::build_w11_22h2),
 
 		MAKE_VARIABLE_PROJECTION_TUPLE_BY_ALIAS(CButton::vftable, "CButton::`vftable'", 0, 0),
-		MAKE_EMPTY_PROJECTION_TUPLE("CButton::Create", 0, os::build_w11_22h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CButton::SetVisualStates", 0, os::build_w11_22h2),
+		MAKE_FUNCTION_PROJECTION_TUPLE(CButton::Create, 0, os::build_w11_22h2),
+		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CButton::SetVisualStates_Win10, "CButton::SetVisualStates", 0, os::build_w11_21h2),
+		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CButton::SetVisualStates_Win11, "CButton::SetVisualStates", os::build_w11_21h2, os::build_w11_22h2),
 		MAKE_EMPTY_PROJECTION_TUPLE("CButton::UpdateCrossfade", 0, os::build_w11_21h2),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -189,7 +189,18 @@ namespace OpenGlass::uDWM
 		}
 		BYTE* IsCloneAllowed()
 		{
-			return &(reinterpret_cast<BYTE*>(this)[84]);
+			BYTE* cloneAllowed{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				cloneAllowed = &(reinterpret_cast<BYTE*>(this)[84]);
+			}
+			else
+			{
+				cloneAllowed = &(reinterpret_cast<BYTE*>(this)[92]);
+			}
+
+			return cloneAllowed;
 		}
 		VisualCollection* GetVisualCollection()
 		{
@@ -243,6 +254,10 @@ namespace OpenGlass::uDWM
 		DECLSPEC_PROJECTION void STDMETHODCALLTYPE SetDirtyFlags(int flags)
 		{
 			return HANDLE_PROJECTION_FUNCTION(CVisual::SetDirtyFlags, flags);
+		}
+		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE RenderRecursive()
+		{
+			return HANDLE_PROJECTION_FUNCTION(CVisual::RenderRecursive);
 		}
 	};
 
@@ -439,7 +454,18 @@ namespace OpenGlass::uDWM
 		}
 		BYTE* GetButtonState()
 		{
-			return &(reinterpret_cast<BYTE*>(this)[280]);
+			BYTE* buttonState{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				buttonState = &(reinterpret_cast<BYTE*>(this)[280]);
+			}
+			else
+			{
+				buttonState = &(reinterpret_cast<BYTE*>(this)[288]);
+			}
+
+			return buttonState;
 		}
 		CTimeline* GetTimeline()
 		{
@@ -447,11 +473,33 @@ namespace OpenGlass::uDWM
 		}
 		CBitmapSourceArray* GetGlyphBitmapArray()
 		{
-			return reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 304);
+			CBitmapSourceArray* glyphBitmapArray{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				glyphBitmapArray = reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 304);
+			}
+			else
+			{
+				glyphBitmapArray = reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 312);
+			}
+
+			return glyphBitmapArray;
 		}
 		CBitmapSourceArray* GetButtonBitmapArray()
 		{
-			return reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 336);
+			CBitmapSourceArray* buttonBitmapArray{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				buttonBitmapArray = reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 336);
+			}
+			else
+			{
+				buttonBitmapArray = reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 344);
+			}
+
+			return buttonBitmapArray;
 		}
 	};
 
@@ -1807,7 +1855,6 @@ namespace OpenGlass::uDWM
 		MAKE_VARIABLE_PROJECTION_TUPLE_BY_ALIAS(CVisual::s_dtor, "CVisual::~CVisual", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::Initialize", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::CloneVisualTree", 0, 0),
-		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::RenderRecursive", 0, os::build_w11_21h2),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::InitializeFromSharedHandle, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetParent, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetSize, 0, 0),
@@ -1816,6 +1863,7 @@ namespace OpenGlass::uDWM
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::InitializeVisualTreeClone, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::ValidateVisual, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetDirtyFlags, 0, 0),
+		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::RenderRecursive, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(VisualCollection::Remove, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(VisualCollection::RemoveAll, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(VisualCollection::InsertRelative, 0, 0),
@@ -1825,12 +1873,12 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CText::InitializeVisualTreeClone", 0, os::build_w11_22h2),
 		MAKE_EMPTY_PROJECTION_TUPLE("CText::`scalar deleting destructor'", 0, os::build_w11_22h2),
 
-		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::CloneVisualTree", 0, os::build_w11_21h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::InitializeVisualTreeClone", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::CloneVisualTree", 0, os::build_w11_22h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::InitializeVisualTreeClone", 0, os::build_w11_22h2),
 
 		MAKE_VARIABLE_PROJECTION_TUPLE_BY_ALIAS(CButton::vftable, "CButton::`vftable'", 0, 0),
-		MAKE_EMPTY_PROJECTION_TUPLE("CButton::Create", 0, os::build_w11_21h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CButton::SetVisualStates", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::Create", 0, os::build_w11_22h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::SetVisualStates", 0, os::build_w11_22h2),
 		MAKE_EMPTY_PROJECTION_TUPLE("CButton::UpdateCrossfade", 0, os::build_w11_21h2),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -187,6 +187,10 @@ namespace OpenGlass::uDWM
 			}
 			return pt;
 		}
+		BYTE* IsCloneAllowed()
+		{
+			return &(reinterpret_cast<BYTE*>(this)[84]);
+		}
 		VisualCollection* GetVisualCollection()
 		{
 			if (g_buildNumber < os::build_w11_24h2)
@@ -411,9 +415,44 @@ namespace OpenGlass::uDWM
 		}
 	};
 
-	struct CButton : CVisual
+	struct CBitmapSource {};
+	struct CBitmapSourceArray : DynArray<CBitmapSource*> {};
+
+	struct CAtlasedRectsVisual : CVisual {};
+	struct CTopLevelAtlasedRectsVisual : CAtlasedRectsVisual {};
+	struct CAtlasedImage
+	{
+		DWORD GetPartId() const
+		{
+			return reinterpret_cast<DWORD const*>(this)[30];
+		}
+	};
+
+	struct CTimeline {};
+	struct CButton : CAtlasedRectsVisual
 	{
 		inline static PVOID* vftable{ nullptr };
+
+		float GetGlyphOpacity()
+		{
+			return reinterpret_cast<float*>(this)[101];
+		}
+		BYTE* GetButtonState()
+		{
+			return &(reinterpret_cast<BYTE*>(this)[280]);
+		}
+		CTimeline* GetTimeline()
+		{
+			return reinterpret_cast<CTimeline**>(this)[49];
+		}
+		CBitmapSourceArray* GetGlyphBitmapArray()
+		{
+			return reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 304);
+		}
+		CBitmapSourceArray* GetButtonBitmapArray()
+		{
+			return reinterpret_cast<CBitmapSourceArray*>(reinterpret_cast<ULONG_PTR>(this) + 336);
+		}
 	};
 
 	struct ACCENT_POLICY
@@ -1198,6 +1237,16 @@ namespace OpenGlass::uDWM
 			return parameters;
 		}
 
+		CButton* GetButton(int index)
+		{
+			CButton** button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 8 * (index + 61));
+			if (button && *button)
+			{
+				return *button;
+			}
+			return nullptr;
+		}
+
 		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE CloneVisualTreeForLivePreview_Win10(
 			bool windowFramesOnly,
 			bool unused1,
@@ -1758,6 +1807,7 @@ namespace OpenGlass::uDWM
 		MAKE_VARIABLE_PROJECTION_TUPLE_BY_ALIAS(CVisual::s_dtor, "CVisual::~CVisual", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::Initialize", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::CloneVisualTree", 0, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::RenderRecursive", 0, os::build_w11_21h2),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::InitializeFromSharedHandle, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetParent, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetSize, 0, 0),
@@ -1775,7 +1825,13 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CText::InitializeVisualTreeClone", 0, os::build_w11_22h2),
 		MAKE_EMPTY_PROJECTION_TUPLE("CText::`scalar deleting destructor'", 0, os::build_w11_22h2),
 
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::CloneVisualTree", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::InitializeVisualTreeClone", 0, os::build_w11_21h2),
+
 		MAKE_VARIABLE_PROJECTION_TUPLE_BY_ALIAS(CButton::vftable, "CButton::`vftable'", 0, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::Create", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::SetVisualStates", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::UpdateCrossfade", 0, os::build_w11_21h2),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CRenderDataVisual::Create, 0, 0),
@@ -1785,10 +1841,12 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CAccent::UpdateAccentPolicy", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CAccent::_UpdateSolidFill", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CAccentBlurBehind::IsBlurBehindDirty", 0, os::build_w11_22h2),
-		
+
 		MAKE_FUNCTION_PROJECTION_TUPLE(CWindowBorder::EnableBorder, os::build_w11_21h2, 0),
 
-		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CTopLevelWindow::CloneVisualTreeForLivePreview_Win10, "CTopLevelWindow::CloneVisualTreeForLivePreview", os::build_w11_21h2, os::build_w11_22h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelAtlasedRectsVisual::ShouldCloneAtlasImage", 0, 0),
+
+		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CTopLevelWindow::CloneVisualTreeForLivePreview_Win10, "CTopLevelWindow::CloneVisualTreeForLivePreview", 0, os::build_w11_22h2),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CTopLevelWindow::CloneVisualTreeForLivePreview_Win11, "CTopLevelWindow::CloneVisualTreeForLivePreview", os::build_w11_22h2, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CTopLevelWindow::GetActualWindowRect, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CTopLevelWindow::TreatAsActiveWindow, 0, 0),


### PR DESCRIPTION
Include stuff to change some live preview/aero peek clone behaviour, like:
- Don't show live preview textures when closing/minimizing window, should fix square corners close/minimize animation while using theme with rounded borders
- Show window frames on live preview focused window.
- Implement button visual clone for Windows 10.

![opl2](https://github.com/user-attachments/assets/5105b37b-3f3b-487e-b7dd-22ef6d121509)


Also include workaround for #50 