### PR TITLE
Restore Vista/7/8 caption button sizes

### DIFF
--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -638,12 +638,11 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaPosit
 	int offsetRight = maximized ? borderMargins.cxRightWidth + 2 : (borderMargins.cxRightWidth ? borderMargins.cxRightWidth - 2 : This->GetFrameThickness() - 2);
 	int offsetTop = maximized ? visibleMargins.cyTopHeight - 1 : visibleMargins.cyTopHeight + 1;
 
-	auto closeButtonSize = CalculateButtonSize(cySize, 3);
+	auto closeButtonSize = loneButton ? CalculateButtonSize(cySize, 0) : CalculateButtonSize(cySize, 3);
 	auto maxButtonSize = CalculateButtonSize(cySize, 2);
 	auto minButtonSize = CalculateButtonSize(cySize, 1);
-	auto loneButtonSize = CalculateButtonSize(cySize, 0);
 
-	if (UpdateButton(3, offsetRight, offsetTop, loneButton ? loneButtonSize : closeButtonSize) && !toolWindow)
+	if (UpdateButton(3, offsetRight, offsetTop, closeButtonSize) && !toolWindow)
 	{
 		offsetRight = closeButtonSize.cx + offsetRight;
 	}

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -319,14 +319,9 @@ void GlassFrameHandler::UpdateWindowButtons(uDWM::CTopLevelWindow* window)
 		return;
 	}
 
-	HWND hwnd = data->GetHwnd();
-	if (!hwnd)
-	{
-		return;
-	}
-
-	auto maximized = IsZoomed(hwnd);
-	auto windowStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+	auto maximized = window->IsWindowMaximized();
+	auto toolWindow = window->IsToolWindow();
+	auto loneButton = window->IsLoneButton();
 	auto& visibleMargins = window->GetMarginsVisibleOutside(maximized);
 	auto& borderMargins = window->GetBorderMargins();
 
@@ -355,7 +350,7 @@ void GlassFrameHandler::UpdateWindowButtons(uDWM::CTopLevelWindow* window)
 	auto minButtonSize = CalculateButtonSize(cySize, 1);
 	auto loneButtonSize = CalculateButtonSize(cySize, 0);
 
-	if (windowStyle & WS_EX_TOOLWINDOW)
+	if (toolWindow)
 	{
 		int cySmSize = GetSystemMetricsForDpi(SM_CYSMSIZE, data->GetWindowDPI());
 		SIZE toolButtonSize = { cySmSize , cySmSize };
@@ -367,7 +362,7 @@ void GlassFrameHandler::UpdateWindowButtons(uDWM::CTopLevelWindow* window)
 		return;
 	}
 
-	if (window->GetButton(3) && !window->GetButton(2) && !window->GetButton(1) && !window->GetButton(0))
+	if (loneButton)
 	{
 		UpdateButton(3, offsetRight, offsetTop, loneButtonSize);
 		return;

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -127,7 +127,6 @@ namespace OpenGlass::GlassFrameHandler
 
 	SIZE CalculateButtonSize(int cySize, int buttonType);
 	HRESULT UpdateReflectionViewport(uDWM::CTopLevelWindow* window);
-	void UpdateWindowButtons(uDWM::CTopLevelWindow* window);
 }
 
 SIZE GlassFrameHandler::CalculateButtonSize(int cySize, int buttonType)
@@ -309,81 +308,6 @@ HRESULT GlassFrameHandler::UpdateReflectionViewport(uDWM::CTopLevelWindow* windo
 	}
 
 	return S_OK;
-}
-
-void GlassFrameHandler::UpdateWindowButtons(uDWM::CTopLevelWindow* window)
-{
-	auto data = window->GetData();
-	if (!data)
-	{
-		return;
-	}
-
-	auto maximized = window->IsWindowMaximized();
-	auto toolWindow = window->IsToolWindow();
-	auto loneButton = window->IsLoneButton();
-	auto& visibleMargins = window->GetMarginsVisibleOutside(maximized);
-	auto& borderMargins = window->GetBorderMargins();
-
-	auto UpdateButton = [&](int buttonType, int offsetRight, int offsetTop, SIZE buttonSize)
-		{
-			if (auto button = window->GetButton(buttonType); button)
-			{
-				MARGINS inset = { 0x7FFFFFFF, offsetRight, offsetTop, 0x7FFFFFFF };
-
-				g_CButton_SetSize_Org(button, &buttonSize);
-				button->SetInsetFromParent(inset);
-				*button->GetGlyphOpacity() = 1.f;
-
-				return true;
-			}
-			return false;
-		};
-
-	int cySize = GetSystemMetricsForDpi(SM_CYSIZE, data->GetWindowDPI());
-
-	int offsetRight = maximized ? borderMargins.cxRightWidth + 2 : (borderMargins.cxRightWidth ? borderMargins.cxRightWidth - 2 : window->GetFrameThickness() - 2);
-	int offsetTop = maximized ? visibleMargins.cyTopHeight - 1 : visibleMargins.cyTopHeight + 1;
-
-	auto closeButtonSize = CalculateButtonSize(cySize, 3);
-	auto maxButtonSize = CalculateButtonSize(cySize, 2);
-	auto minButtonSize = CalculateButtonSize(cySize, 1);
-	auto loneButtonSize = CalculateButtonSize(cySize, 0);
-
-	if (toolWindow)
-	{
-		int cySmSize = GetSystemMetricsForDpi(SM_CYSMSIZE, data->GetWindowDPI());
-		SIZE toolButtonSize = { cySmSize , cySmSize };
-		if (borderMargins.cyTopHeight - toolButtonSize.cy - 4 > visibleMargins.cyTopHeight)
-		{
-			offsetTop = borderMargins.cyTopHeight - toolButtonSize.cy - 4;
-		}
-		UpdateButton(3, offsetRight, offsetTop, toolButtonSize);
-		return;
-	}
-
-	if (loneButton)
-	{
-		UpdateButton(3, offsetRight, offsetTop, loneButtonSize);
-		return;
-	}
-
-	if (UpdateButton(3, offsetRight, offsetTop, closeButtonSize))
-	{
-		offsetRight = closeButtonSize.cx + offsetRight;
-	}
-
-	if (UpdateButton(2, offsetRight, offsetTop, maxButtonSize))
-	{
-		offsetRight += maxButtonSize.cx;
-	}
-
-	if (UpdateButton(1, offsetRight, offsetTop, minButtonSize))
-	{
-		offsetRight += minButtonSize.cx;
-	}
-
-	UpdateButton(0, offsetRight, offsetTop, minButtonSize);
 }
 
 HRGN WINAPI GlassFrameHandler::MyCreateRoundRectRgn(int x1, int y1, int x2, int y2, int w, int h)
@@ -670,7 +594,6 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaBackg
 
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes(uDWM::CTopLevelWindow* This)
 {
-
 	auto hr = g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org(This);
 
 	if (!g_captionButtons)
@@ -678,9 +601,74 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaPosit
 		return hr;
 	}
 
+	auto data = This->GetData();
+	if (!data)
+	{
+		return hr;
+	}
+
+	auto maximized = This->IsWindowMaximized();
+	auto toolWindow = This->IsToolWindow();
+	auto loneButton = This->IsLoneButton();
+
+	auto& visibleMargins = This->GetMarginsVisibleOutside(maximized);
+	auto& borderMargins = This->GetBorderMargins();
+
 	RECT rect{ 0 };
 	This->GetActualWindowRect(&rect, true, true, true);
 	int cxLeft = (rect.left < 0) ? -rect.left : This->GetFrameThickness();
+
+	auto UpdateButton = [&](int buttonType, int offsetRight, int offsetTop, SIZE buttonSize)
+		{
+			if (auto button = This->GetButton(buttonType); button)
+			{
+				MARGINS inset = { 0x7FFFFFFF, offsetRight, offsetTop, 0x7FFFFFFF };
+
+				g_CButton_SetSize_Org(button, &buttonSize);
+				button->SetInsetFromParent(inset);
+				*button->GetGlyphOpacity() = 1.f;
+
+				return true;
+			}
+			return false;
+		};
+
+	int cySize = GetSystemMetricsForDpi(SM_CYSIZE, data->GetWindowDPI());
+
+	int offsetRight = maximized ? borderMargins.cxRightWidth + 2 : (borderMargins.cxRightWidth ? borderMargins.cxRightWidth - 2 : This->GetFrameThickness() - 2);
+	int offsetTop = maximized ? visibleMargins.cyTopHeight - 1 : visibleMargins.cyTopHeight + 1;
+
+	auto closeButtonSize = CalculateButtonSize(cySize, 3);
+	auto maxButtonSize = CalculateButtonSize(cySize, 2);
+	auto minButtonSize = CalculateButtonSize(cySize, 1);
+	auto loneButtonSize = CalculateButtonSize(cySize, 0);
+
+	if (UpdateButton(3, offsetRight, offsetTop, loneButton ? loneButtonSize : closeButtonSize) && !toolWindow)
+	{
+		offsetRight = closeButtonSize.cx + offsetRight;
+	}
+
+	if (UpdateButton(2, offsetRight, offsetTop, maxButtonSize))
+	{
+		offsetRight += maxButtonSize.cx;
+	}
+
+	if (UpdateButton(1, offsetRight, offsetTop, minButtonSize))
+	{
+		offsetRight += minButtonSize.cx;
+	}
+
+	UpdateButton(0, offsetRight, offsetTop, minButtonSize);
+
+	if (toolWindow)
+	{
+		int cySmSize = GetSystemMetricsForDpi(SM_CYSMSIZE, data->GetWindowDPI());
+		SIZE toolButtonSize = { cySmSize , cySmSize };
+
+		offsetTop = (borderMargins.cyTopHeight - toolButtonSize.cy - 4 > offsetTop) ? borderMargins.cyTopHeight - toolButtonSize.cy - 4 : offsetTop;
+		UpdateButton(3, offsetRight, offsetTop, toolButtonSize);
+		offsetRight = toolButtonSize.cx + offsetRight;
+	}
 
 	if (auto iconVisual = This->GetIconVisual(); iconVisual && cxLeft > 0)
 	{
@@ -693,10 +681,9 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaPosit
 		{
 			cxLeft += iconVisual->GetWidth() ? iconVisual->GetWidth() + 5 : 0;
 		}
-		textVisual->SetInsetFromParentLeft(cxLeft);
+		MARGINS inset = { cxLeft, offsetRight, visibleMargins.cyTopHeight, 0x7FFFFFFF };
+		textVisual->SetInsetFromParent(inset);
 	}
-
-	UpdateWindowButtons(This);
 
 	return hr;
 }

--- a/OpenGlass/GlassFrameHandler.cpp
+++ b/OpenGlass/GlassFrameHandler.cpp
@@ -19,6 +19,7 @@ namespace OpenGlass::GlassFrameHandler
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10(uDWM::CTopLevelWindow* This, bool windowFramesOnly, bool unused1, bool unused2, uDWM::CTopLevelWindow** clonedWindow);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11(uDWM::CTopLevelWindow* This, bool windowFramesOnly, uDWM::CTopLevelWindow** clonedWindow);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_UpdateNCAreaBackground(uDWM::CTopLevelWindow* This);
+	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes(uDWM::CTopLevelWindow* This);
 	HRESULT STDMETHODCALLTYPE MyCTopLevelWindow_UpdateClientBlur(uDWM::CTopLevelWindow* This);
 	HRESULT STDMETHODCALLTYPE MyCButton_CloneVisualTree(uDWM::CButton* This, uDWM::CButton** clonedVisual, UINT cloneOption);
 	void STDMETHODCALLTYPE MyCButton_SetSize(uDWM::CButton* This, const SIZE* size);
@@ -42,6 +43,7 @@ namespace OpenGlass::GlassFrameHandler
 	decltype(&MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win10) g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win10_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_CloneVisualTreeForLivePreview_Win11) g_CTopLevelWindow_CloneVisualTreeForLivePreview_Win11_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_UpdateNCAreaBackground) g_CTopLevelWindow_UpdateNCAreaBackground_Org{ nullptr };
+	decltype(&MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes) g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_UpdateClientBlur) g_CTopLevelWindow_UpdateClientBlur_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_ValidateVisual) g_CTopLevelWindow_ValidateVisual_Org{ nullptr };
 	decltype(&MyCTopLevelWindow_Destructor) g_CTopLevelWindow_Destructor_Org{ nullptr };
@@ -115,8 +117,69 @@ namespace OpenGlass::GlassFrameHandler
 	bool g_systemBackdrop{ false };
 	std::optional<bool> g_redirectFirstCreateRectRgnCall{};
 	bool g_windowFramesOnly{ false };
+	enum CaptionButtons : UINT
+	{
+		Disabled = 0,
+		WindowsVista,
+		Windows7,
+		Windows8
+	} g_captionButtons{ 0 };
 
+	SIZE CalculateButtonSize(int cySize, int buttonType);
 	HRESULT UpdateReflectionViewport(uDWM::CTopLevelWindow* window);
+	void UpdateWindowButtons(uDWM::CTopLevelWindow* window);
+}
+
+SIZE GlassFrameHandler::CalculateButtonSize(int cySize, int buttonType)
+{
+	enum
+	{
+		LoneButton = 0,
+		MinButton,
+		MaxButton,
+		CloseButton,
+	};
+
+	auto [heightRatio, loneWidthRatio, closeWidthRatio, maxWidthRatio, minWidthRatio] = std::make_tuple(0.f, 0.f, 0.f, 0.f, 0.f);
+
+	switch (g_captionButtons)
+	{
+	case CaptionButtons::WindowsVista:
+		std::tie(heightRatio, loneWidthRatio, closeWidthRatio, maxWidthRatio, minWidthRatio) =
+			std::make_tuple(0.94736844f, 2.3157895f, 2.3157895f, 1.3157895f, 1.3684211f);
+		break;
+	case CaptionButtons::Windows7:
+	default:
+		std::tie(heightRatio, loneWidthRatio, closeWidthRatio, maxWidthRatio, minWidthRatio) =
+			std::make_tuple(0.95238096f, 2.3333333f, 2.3333333f, 1.2857143f, 1.3809524f);
+		break;
+	case CaptionButtons::Windows8:
+		std::tie(heightRatio, loneWidthRatio, closeWidthRatio, maxWidthRatio, minWidthRatio) =
+			std::make_tuple(0.95454544f, 1.6363636f, 2.2272727f, 1.2272727f, 1.3181819f);
+		break;
+	}
+
+	SIZE buttonSize = { 0, static_cast<LONG>(std::round(static_cast<float>(cySize) * heightRatio)) };
+
+	switch (buttonType)
+	{
+	case CloseButton:
+		buttonSize.cx = static_cast<LONG>(std::round(static_cast<float>(cySize) * closeWidthRatio));
+		break;
+	case MaxButton:
+		buttonSize.cx = static_cast<LONG>(std::round(static_cast<float>(cySize) * maxWidthRatio));
+		break;
+	case MinButton:
+		buttonSize.cx = static_cast<LONG>(std::round(static_cast<float>(cySize) * minWidthRatio));
+		break;
+	case LoneButton:
+		buttonSize.cx = static_cast<LONG>(std::round(static_cast<float>(cySize) * loneWidthRatio));
+		break;
+	default:
+		break;
+	}
+
+	return buttonSize;
 }
 
 HRESULT GlassFrameHandler::UpdateReflectionViewport(uDWM::CTopLevelWindow* window)
@@ -246,6 +309,86 @@ HRESULT GlassFrameHandler::UpdateReflectionViewport(uDWM::CTopLevelWindow* windo
 	}
 
 	return S_OK;
+}
+
+void GlassFrameHandler::UpdateWindowButtons(uDWM::CTopLevelWindow* window)
+{
+	auto data = window->GetData();
+	if (!data)
+	{
+		return;
+	}
+
+	HWND hwnd = data->GetHwnd();
+	if (!hwnd)
+	{
+		return;
+	}
+
+	auto maximized = IsZoomed(hwnd);
+	auto windowStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+	auto& visibleMargins = window->GetMarginsVisibleOutside(maximized);
+	auto& borderMargins = window->GetBorderMargins();
+
+	auto UpdateButton = [&](int buttonType, int offsetRight, int offsetTop, SIZE buttonSize)
+		{
+			if (auto button = window->GetButton(buttonType); button)
+			{
+				MARGINS inset = { 0x7FFFFFFF, offsetRight, offsetTop, 0x7FFFFFFF };
+
+				g_CButton_SetSize_Org(button, &buttonSize);
+				button->SetInsetFromParent(inset);
+				*button->GetGlyphOpacity() = 1.f;
+
+				return true;
+			}
+			return false;
+		};
+
+	int cySize = GetSystemMetricsForDpi(SM_CYSIZE, data->GetWindowDPI());
+
+	int offsetRight = maximized ? borderMargins.cxRightWidth + 2 : (borderMargins.cxRightWidth ? borderMargins.cxRightWidth - 2 : window->GetFrameThickness() - 2);
+	int offsetTop = maximized ? visibleMargins.cyTopHeight - 1 : visibleMargins.cyTopHeight + 1;
+
+	auto closeButtonSize = CalculateButtonSize(cySize, 3);
+	auto maxButtonSize = CalculateButtonSize(cySize, 2);
+	auto minButtonSize = CalculateButtonSize(cySize, 1);
+	auto loneButtonSize = CalculateButtonSize(cySize, 0);
+
+	if (windowStyle & WS_EX_TOOLWINDOW)
+	{
+		int cySmSize = GetSystemMetricsForDpi(SM_CYSMSIZE, data->GetWindowDPI());
+		SIZE toolButtonSize = { cySmSize , cySmSize };
+		if (borderMargins.cyTopHeight - toolButtonSize.cy - 4 > visibleMargins.cyTopHeight)
+		{
+			offsetTop = borderMargins.cyTopHeight - toolButtonSize.cy - 4;
+		}
+		UpdateButton(3, offsetRight, offsetTop, toolButtonSize);
+		return;
+	}
+
+	if (window->GetButton(3) && !window->GetButton(2) && !window->GetButton(1) && !window->GetButton(0))
+	{
+		UpdateButton(3, offsetRight, offsetTop, loneButtonSize);
+		return;
+	}
+
+	if (UpdateButton(3, offsetRight, offsetTop, closeButtonSize))
+	{
+		offsetRight = closeButtonSize.cx + offsetRight;
+	}
+
+	if (UpdateButton(2, offsetRight, offsetTop, maxButtonSize))
+	{
+		offsetRight += maxButtonSize.cx;
+	}
+
+	if (UpdateButton(1, offsetRight, offsetTop, minButtonSize))
+	{
+		offsetRight += minButtonSize.cx;
+	}
+
+	UpdateButton(0, offsetRight, offsetTop, minButtonSize);
 }
 
 HRGN WINAPI GlassFrameHandler::MyCreateRoundRectRgn(int x1, int y1, int x2, int y2, int w, int h)
@@ -530,6 +673,39 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaBackg
 	return hr;
 }
 
+HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes(uDWM::CTopLevelWindow* This)
+{
+
+	auto hr = g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org(This);
+
+	if (!g_captionButtons)
+	{
+		return hr;
+	}
+
+	RECT rect{ 0 };
+	This->GetActualWindowRect(&rect, true, true, true);
+	int cxLeft = (rect.left < 0) ? -rect.left : This->GetFrameThickness();
+
+	if (auto iconVisual = This->GetIconVisual(); iconVisual && cxLeft > 0)
+	{
+		iconVisual->SetInsetFromParentLeft(cxLeft);
+	}
+
+	if (auto textVisual = This->GetTextVisual(); textVisual)
+	{
+		if (auto iconVisual = This->GetIconVisual(); iconVisual && cxLeft > 0)
+		{
+			cxLeft += iconVisual->GetWidth() ? iconVisual->GetWidth() + 5 : 0;
+		}
+		textVisual->SetInsetFromParentLeft(cxLeft);
+	}
+
+	UpdateWindowButtons(This);
+
+	return hr;
+}
+
 HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCTopLevelWindow_UpdateClientBlur(uDWM::CTopLevelWindow* This)
 {
 	const auto hr = g_CTopLevelWindow_UpdateClientBlur_Org(This);
@@ -627,7 +803,7 @@ HRESULT STDMETHODCALLTYPE GlassFrameHandler::MyCButton_CloneVisualTree(uDWM::CBu
 		(*clonedVisual)->SetVisualStates(
 			This->GetGlyphBitmapArray(),
 			This->GetButtonBitmapArray(),
-			This->GetGlyphOpacity()
+			*This->GetGlyphOpacity()
 		)
 	);
 
@@ -787,6 +963,7 @@ void GlassFrameHandler::Update(GlassEngine::UpdateType type)
 	if (type & GlassEngine::UpdateType::Theme)
 	{
 		Shared::g_disableModernBorders = static_cast<bool>(GlassEngine::GetDwordFromRegistry(L"DisableModernBorders", FALSE));
+		g_captionButtons = static_cast<CaptionButtons>(GlassEngine::GetDwordFromRegistry(L"CaptionButtons", 0));
 	}
 }
 
@@ -795,6 +972,7 @@ void GlassFrameHandler::Startup()
 	uDWM::g_projectionArray.ApplyToVariable("ResourceHelper::CreateGeometryFromHRGN", g_ResourceHelper_CreateGeometryFromHRGN_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelAtlasedRectsVisual::ShouldCloneAtlasImage", g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateNCAreaBackground", g_CTopLevelWindow_UpdateNCAreaBackground_Org);
+	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateNCAreaPositionsAndSizes", g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateClientBlur", g_CTopLevelWindow_UpdateClientBlur_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::ValidateVisual", g_CTopLevelWindow_ValidateVisual_Org);
 	uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::~CTopLevelWindow", g_CTopLevelWindow_Destructor_Org);
@@ -971,6 +1149,7 @@ void GlassFrameHandler::Startup()
 			HookHelper::Detours::Attach(&g_ResourceHelper_CreateGeometryFromHRGN_Org, MyResourceHelper_CreateGeometryFromHRGN);
 			HookHelper::Detours::Attach(&g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org, MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage);
 			HookHelper::Detours::Attach(&g_CTopLevelWindow_UpdateNCAreaBackground_Org, MyCTopLevelWindow_UpdateNCAreaBackground);
+			HookHelper::Detours::Attach(&g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org, MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes);
 			HookHelper::Detours::Attach(&g_CTopLevelWindow_UpdateClientBlur_Org, MyCTopLevelWindow_UpdateClientBlur);
 			
 			if (uDWM::g_buildNumber <= os::build_w11_21h2)
@@ -1001,6 +1180,7 @@ void GlassFrameHandler::Shutdown()
 			HookHelper::Detours::Detach(&g_ResourceHelper_CreateGeometryFromHRGN_Org, MyResourceHelper_CreateGeometryFromHRGN);
 			HookHelper::Detours::Detach(&g_CTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage_Org, MyCTopLevelAtlasedRectsVisual_ShouldCloneAtlasImage);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_UpdateNCAreaBackground_Org, MyCTopLevelWindow_UpdateNCAreaBackground);
+			HookHelper::Detours::Detach(&g_CTopLevelWindow_UpdateNCAreaPositionsAndSizes_Org, MyCTopLevelWindow_UpdateNCAreaPositionsAndSizes);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_UpdateClientBlur_Org, MyCTopLevelWindow_UpdateClientBlur);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_Destructor_Org, MyCTopLevelWindow_Destructor);
 			HookHelper::Detours::Detach(&g_CTopLevelWindow_ValidateVisual_Org, MyCTopLevelWindow_ValidateVisual);

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -344,6 +344,10 @@ namespace OpenGlass::uDWM
 		{
 			return HANDLE_PROJECTION_FUNCTION(CVisual::SetInsetFromParent, margins);
 		}
+		DECLSPEC_PROJECTION void STDMETHODCALLTYPE SetInsetFromParentLeft(int left)
+		{
+			return HANDLE_PROJECTION_FUNCTION(CVisual::SetInsetFromParentLeft, left);
+		}
 		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE InitializeVisualTreeClone(
 			CVisual* clonedVisual,
 			UINT cloneOption
@@ -561,6 +565,8 @@ namespace OpenGlass::uDWM
 		}
 	};
 
+	struct CImage : CVisual {};
+
 	struct CBitmapSource : CBaseObject {};
 	struct CBitmapSourceArray : DynArray<CBitmapSource*> {};
 
@@ -626,7 +632,7 @@ namespace OpenGlass::uDWM
 			float opacity
 		)
 		{
-			if (g_buildNumber < os::build_w11_22h2) [[likely]]
+			if (g_buildNumber < os::build_w11_21h2) [[likely]]
 			{
 				return SetVisualStates_Win10(
 					buttonArray,
@@ -645,9 +651,21 @@ namespace OpenGlass::uDWM
 			}
 		}
 
-		float GetGlyphOpacity()
+		float* GetGlyphOpacity()
 		{
-			return reinterpret_cast<float*>(this)[101];
+			float* glyphOpacity{ nullptr };
+
+			if (g_buildNumber < os::build_w11_24h2)
+			{
+				glyphOpacity = &(reinterpret_cast<float*>(this)[101]);
+			}
+
+			else
+			{
+				glyphOpacity = &(reinterpret_cast<float*>(this)[89]);
+			}
+
+			return glyphOpacity;
 		}
 		BYTE* GetButtonState()
 		{
@@ -896,6 +914,26 @@ namespace OpenGlass::uDWM
 			return *captionColor;
 		}
 
+		UINT GetWindowDPI() const
+		{
+			UINT dpi{ 0 };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				dpi = *reinterpret_cast<UINT const*>(reinterpret_cast<ULONG_PTR>(this) + 324);
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				dpi = *reinterpret_cast<UINT const*>(reinterpret_cast<ULONG_PTR>(this) + 348);
+			}
+			else
+			{
+				dpi = reinterpret_cast<UINT const*>(this)[87];
+			}
+
+			return dpi;
+		}
+
 		BYTE GetNonClientAttribute() const
 		{
 			BYTE attribute{ 0 };
@@ -1062,6 +1100,37 @@ namespace OpenGlass::uDWM
 			else if (g_buildNumber < os::build_w11_22h2)
 			{
 				visual = reinterpret_cast<CText* const*>(this)[67];
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				visual = reinterpret_cast<CText* const*>(this)[70];
+			}
+			else
+			{
+				visual = reinterpret_cast<CText* const*>(this)[65];
+			}
+
+			return visual;
+		}
+		CImage* GetIconVisual() const
+		{
+			CImage* visual{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				visual = reinterpret_cast<CImage* const*>(this)[66];
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				visual = reinterpret_cast<CImage* const*>(this)[68];
+			}
+			else if (g_buildNumber < os::build_w11_23h2)
+			{
+				visual = reinterpret_cast<CImage* const*>(this)[72];
+			}
+			else
+			{
+				visual = reinterpret_cast<CImage* const*>(this)[67];
 			}
 
 			return visual;
@@ -1485,12 +1554,96 @@ namespace OpenGlass::uDWM
 
 		CButton* GetButton(int index)
 		{
-			CButton** button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 8 * (index + 61));
+			CButton** button = nullptr;
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 8 * (index + 61));
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 8 * (index + 63));
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 8 * (index + 66));
+			}
+			else
+			{
+				button = reinterpret_cast<CButton**>(reinterpret_cast<ULONG_PTR>(this) + 488 + 8 * index);
+			}
+
 			if (button && *button)
 			{
 				return *button;
 			}
+
 			return nullptr;
+		}
+
+		DWORD GetFrameThickness(CWindowData* data = nullptr)
+		{
+			if (!data)
+			{
+				data = GetData();
+			}
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				return reinterpret_cast<DWORD const*>(data)[24];
+			}
+			else
+			{
+				return reinterpret_cast<DWORD const*>(data)[17];
+			}
+
+			return 0;
+		}
+		MARGINS& GetMarginsVisibleOutside(bool zoomed)
+		{
+			MARGINS* margins{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + (zoomed ? 644 : 628));
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + (zoomed ? 660 : 644));
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + (zoomed ? 676 : 660));
+			}
+			else
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + (zoomed ? 636 : 620));
+			}
+
+			return *margins;
+		}
+		MARGINS& GetBorderMargins()
+		{
+			MARGINS* margins{ nullptr };
+
+			if (g_buildNumber < os::build_w11_21h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + 596);
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + 612);
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + 628);
+			}
+			else
+			{
+				margins = reinterpret_cast<MARGINS*>(reinterpret_cast<ULONG_PTR>(this) + 588);
+			}
+
+			return *margins;
 		}
 
 		DECLSPEC_PROJECTION HRESULT STDMETHODCALLTYPE CloneVisualTreeForLivePreview_Win10(
@@ -2074,6 +2227,7 @@ namespace OpenGlass::uDWM
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetSize, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetInsetFromParent, 0, 0),
+		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetInsetFromParentLeft, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::SetDirtyFlags, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(CVisual::RenderRecursive, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE(VisualCollection::Remove, 0, 0),
@@ -2118,6 +2272,7 @@ namespace OpenGlass::uDWM
 		MAKE_FUNCTION_PROJECTION_TUPLE(CTopLevelWindow::OnSystemBackdropUpdated, os::build_w11_21h2, 0),
 		MAKE_VARIABLE_PROJECTION_TUPLE(CTopLevelWindow::s_rgpwfWindowFrames, 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateNCAreaBackground", 0, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateNCAreaPositionsAndSizes", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateClientBlur", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::ValidateVisual", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateWindowVisuals", 0, 0),

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -1463,6 +1463,88 @@ namespace OpenGlass::uDWM
 
 			return rtlMirrored;
 		}
+		bool IsWindowMaximized()
+		{
+			bool windowMaximized{ false };
+
+			if (g_buildNumber < os::build_w10_2004)
+			{
+				windowMaximized = (reinterpret_cast<DWORD const*>(this)[146] & 0x20) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_21h2)
+			{
+				windowMaximized = (reinterpret_cast<DWORD const*>(this)[148] & 0x20) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				windowMaximized = (reinterpret_cast<DWORD const*>(this)[152] & 0x20) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				windowMaximized = (reinterpret_cast<DWORD const*>(this)[156] & 0x20) != 0;
+			}
+			else
+			{
+				windowMaximized = (reinterpret_cast<DWORD const*>(this)[146] & 0x20) != 0;
+			}
+
+			return windowMaximized;
+		}
+		bool IsToolWindow()
+		{
+			bool toolWindow{ false };
+
+			if (g_buildNumber < os::build_w10_2004)
+			{
+				toolWindow = (reinterpret_cast<DWORD const*>(this)[146] & 2) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_21h2)
+			{
+				toolWindow = (reinterpret_cast<DWORD const*>(this)[148] & 2) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				toolWindow = (reinterpret_cast<DWORD const*>(this)[152] & 2) != 0;
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				toolWindow = (reinterpret_cast<DWORD const*>(this)[156] & 2) != 0;
+			}
+			else
+			{
+				toolWindow = (reinterpret_cast<DWORD const*>(this)[146] & 2) != 0;
+			}
+
+			return toolWindow;
+		}
+		bool IsLoneButton()
+		{
+			bool loneButton{ false };
+
+			if (g_buildNumber < os::build_w10_2004)
+			{
+				loneButton = (reinterpret_cast<DWORD const*>(this)[146] & 0xB00) == 0;
+			}
+			else if (g_buildNumber < os::build_w11_21h2)
+			{
+				loneButton = (reinterpret_cast<DWORD const*>(this)[148] & 0xB00) == 0;
+			}
+			else if (g_buildNumber < os::build_w11_22h2)
+			{
+				loneButton = (reinterpret_cast<DWORD const*>(this)[152] & 0xB00) == 0;
+			}
+			else if (g_buildNumber < os::build_w11_24h2)
+			{
+				loneButton = (reinterpret_cast<DWORD const*>(this)[156] & 0xB00) == 0;
+			}
+			else
+			{
+				loneButton = (reinterpret_cast<DWORD const*>(this)[146] & 0xB00) == 0;
+			}
+
+			return loneButton;
+		}
+
 		bool HasNonClientArea() const
 		{
 			bool hasNonClientArea{ false };
@@ -1580,7 +1662,7 @@ namespace OpenGlass::uDWM
 
 			return nullptr;
 		}
-
+		
 		DWORD GetFrameThickness(CWindowData* data = nullptr)
 		{
 			if (!data)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can change the settings of OpenGlass via editing the Windows registry.
 ### Theme settings
 | Key Name | Type | Description | 
 | -------- | ---- | ----------- |
+| CaptionButtons | DWORD | Changes caption buttons sizes.<ul><li>0x0=Windows 10 style (default)</li><li>0x1=Windows Vista style</li><li>0x2=Windows 7 style</li><li>0x3=Windows 8 style</li></ul> |
 | CenterCaption | DWORD | Controls how title bar text is aligned.<ul><li>0x0=Keeps it on the left (default)</li><li>0x1=Centers it between the titlebar icon and the titlebar buttons</li><li>0x2=Centers the Win8 way</li></ul><br>ℹ️ Only valid in Win10 |
 | TextGlowMode | DWORD | Specifies how window caption glow effect will be rendered <ul><li>0x0=No glow effect</li><li>0x1=Glow effect loaded from atlas (default)</li><li>0x2=Glow effect loaded from atlas and theme opacity is respected</li><li>0x3=Composited glow effect using your theme settings HIWORD of the value specifies glow size (0=theme default)</li></ul><br>ℹ️ Only valid in Win10 |
 | CustomThemeAtlas | String | path to PNG file with theme resource (bitmap must have exactly the same layout as msstyle theme you are using!) |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can change the settings of OpenGlass via editing the Windows registry.
 ### Theme settings
 | Key Name | Type | Description | 
 | -------- | ---- | ----------- |
-| CaptionButtons | DWORD | Changes caption buttons sizes.<ul><li>0x0=Windows 10 style (default)</li><li>0x1=Windows Vista style</li><li>0x2=Windows 7 style</li><li>0x3=Windows 8 style</li></ul> |
+| CaptionButtons | DWORD | Changes caption buttons sizes and the opacity of the button glyphs.<ul><li>0x0=Windows 10 style (default)</li><li>0x1=Windows Vista style</li><li>0x2=Windows 7 style</li><li>0x3=Windows 8 style</li></ul> |
 | CenterCaption | DWORD | Controls how title bar text is aligned.<ul><li>0x0=Keeps it on the left (default)</li><li>0x1=Centers it between the titlebar icon and the titlebar buttons</li><li>0x2=Centers the Win8 way</li></ul><br>ℹ️ Only valid in Win10 |
 | TextGlowMode | DWORD | Specifies how window caption glow effect will be rendered <ul><li>0x0=No glow effect</li><li>0x1=Glow effect loaded from atlas (default)</li><li>0x2=Glow effect loaded from atlas and theme opacity is respected</li><li>0x3=Composited glow effect using your theme settings HIWORD of the value specifies glow size (0=theme default)</li></ul><br>ℹ️ Only valid in Win10 |
 | CustomThemeAtlas | String | path to PNG file with theme resource (bitmap must have exactly the same layout as msstyle theme you are using!) |


### PR DESCRIPTION
Add options to restore caption button size calculation used in Vista/7/8, also the option changes the text and icon margin to better fit themes with frames. 

![captionbuttonsize](https://github.com/user-attachments/assets/a172c28f-33a4-43d6-b72c-79c6c50afd89)
