### PR TITLE
Restore button glow on Windows 11 21H2+

### DIFF
--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -97,11 +97,22 @@ namespace OpenGlass::ButtonGlowHandler
 	// We use external maps to store the glow bitmaps and hook the rendering pipeline.
 
 	std::unordered_map<void*, winrt::com_ptr<uDWM::CBitmapSource>> g_atlasGlowMap;
-	std::unordered_map<void*, winrt::com_ptr<uDWM::CBitmapSource>> g_buttonGlowMap;
+
+	enum class ButtonGlowType { None, MinMax, Close };
+	std::unordered_map<void*, ButtonGlowType> g_buttonGlowMap;
 
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowMinMax;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowClose;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowToolClose;
+
+	uDWM::CBitmapSource* ResolveGlowBitmap(void* button)
+	{
+		auto it = g_buttonGlowMap.find(button);
+		if (it == g_buttonGlowMap.end()) return nullptr;
+		if (it->second == ButtonGlowType::MinMax) return g_glowMinMax.get();
+		if (it->second == ButtonGlowType::Close) return g_glowClose.get();
+		return nullptr;
+	}
 
 	using fn_AppendAtlasNineGrid = HRESULT(__fastcall*)(void*, void*, uDWM::CBitmapSource*);
 	using fn_AddNineGridAtlasSize = void(__fastcall*)(void*, const MARGINS&, unsigned int*);
@@ -111,6 +122,9 @@ namespace OpenGlass::ButtonGlowHandler
 	fn_AddNineGridAtlasSize g_AddNineGridAtlasSize{ nullptr };
 	fn_AtlasedImage_SetDirtyFlags g_AtlasedImage_SetDirtyFlags{ nullptr };
 	fn_CVisual_MoveToFront g_CVisual_MoveToFront{ nullptr };
+
+	using fn_CButton_RedrawVisual = HRESULT(__fastcall*)(void*);
+	fn_CButton_RedrawVisual g_CButton_RedrawVisual_Org{ nullptr };
 
 	// Reuse same CreateBitmapFromAtlas as Win10 (still exists on Win11)
 	HRESULT(WINAPI* CTopLevelWindow__CreateBitmapFromAtlas_Win11)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
@@ -201,11 +215,20 @@ namespace OpenGlass::ButtonGlowHandler
 	{
 		g_CAtlasButton_AddApproxAtlasSize_Org(thisButton, sizeOut);
 
+		if (!g_AddNineGridAtlasSize)
+			return;
+
+		auto* glowRef = g_glowMinMax.get();
+		if (!glowRef) glowRef = g_glowClose.get();
+
 		auto it = g_atlasGlowMap.find(thisButton);
-		if (it != g_atlasGlowMap.end() && it->second && g_AddNineGridAtlasSize)
+		if (it != g_atlasGlowMap.end() && it->second)
+			glowRef = it->second.get();
+
+		if (glowRef)
 		{
 			const auto& margins = *reinterpret_cast<const MARGINS*>(
-				reinterpret_cast<uintptr_t>(it->second.get()) + MARGIN_OFFSET
+				reinterpret_cast<uintptr_t>(glowRef) + MARGIN_OFFSET
 			);
 			g_AddNineGridAtlasSize(thisButton, margins, sizeOut);
 		}
@@ -218,21 +241,38 @@ namespace OpenGlass::ButtonGlowHandler
 
 		uDWM::CBitmapSource* glowBitmap = nullptr;
 
-		// States 1 (hot) and 2 (pressed) show glow, matching Win10 logic: (state - 1 <= 1)
 		if (state >= 1 && state <= 2)
 		{
-			auto it = g_buttonGlowMap.find(thisButton);
-			if (it != g_buttonGlowMap.end() && it->second)
-			{
-				// OpenGlass is active, so glass effects are always enabled — no need for
-				// the CDesktopManager byte 17 check (which is build-specific anyway)
-				if (g_CVisual_MoveToFront)
-					g_CVisual_MoveToFront(thisButton, 0);
-				glowBitmap = it->second.get();
-			}
+			glowBitmap = ResolveGlowBitmap(thisButton);
+			if (glowBitmap && g_CVisual_MoveToFront)
+				g_CVisual_MoveToFront(thisButton, 0);
 		}
 
 		Win11_SetGlowImage(atlasedImage, glowBitmap);
+	}
+
+	HRESULT __fastcall CButton_RedrawVisual_Hook(void* thisButton)
+	{
+		HRESULT hr = g_CButton_RedrawVisual_Org(thisButton);
+
+		auto* button = reinterpret_cast<uDWM::CButton*>(thisButton);
+		unsigned int newState = *button->GetVisualState();
+		void* firstImg = *button->GetFirstAtlasImage();
+
+		if (g_buttonGlowMap.count(thisButton))
+		{
+			uDWM::CBitmapSource* glowBitmap = nullptr;
+			if (newState >= 1 && newState <= 2)
+				glowBitmap = ResolveGlowBitmap(thisButton);
+
+			if (firstImg)
+				Win11_SetGlowImage(firstImg, glowBitmap);
+
+			if (glowBitmap && g_CVisual_MoveToFront)
+				g_CVisual_MoveToFront(thisButton, 0);
+		}
+
+		return hr;
 	}
 
 	// Hook: CTopLevelWindow::UpdateButtonVisuals — associate our stored glow bitmaps with buttons
@@ -245,10 +285,10 @@ namespace OpenGlass::ButtonGlowHandler
 		auto* maxBtn = tlw->GetButton(2);
 		auto* closeBtn = tlw->GetButton(3);
 
-		if (helpBtn)  g_buttonGlowMap[helpBtn].copy_from(g_glowMinMax.get());
-		if (minBtn)   g_buttonGlowMap[minBtn].copy_from(g_glowMinMax.get());
-		if (maxBtn)   g_buttonGlowMap[maxBtn].copy_from(g_glowMinMax.get());
-		if (closeBtn) g_buttonGlowMap[closeBtn].copy_from(g_glowClose.get());
+		if (helpBtn)  g_buttonGlowMap[helpBtn] = ButtonGlowType::MinMax;
+		if (minBtn)   g_buttonGlowMap[minBtn] = ButtonGlowType::MinMax;
+		if (maxBtn)   g_buttonGlowMap[maxBtn] = ButtonGlowType::MinMax;
+		if (closeBtn) g_buttonGlowMap[closeBtn] = ButtonGlowType::Close;
 
 		return g_CTopLevelWindow_UpdateButtonVisuals_Org(thisWindow, windowFrame);
 	}
@@ -301,6 +341,7 @@ namespace OpenGlass::ButtonGlowHandler
 			uDWM::g_projectionArray.ApplyToVariable("CAtlasButton::AppendAtlas", g_CAtlasButton_AppendAtlas_Org);
 			uDWM::g_projectionArray.ApplyToVariable("CAtlasButton::AddApproximateAtlasSize", g_CAtlasButton_AddApproxAtlasSize_Org);
 			uDWM::g_projectionArray.ApplyToVariable("CButton::DrawStateW", g_CButton_DrawStateW_Org);
+			uDWM::g_projectionArray.ApplyToVariable("CButton::RedrawVisual", g_CButton_RedrawVisual_Org);
 			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateButtonVisuals", g_CTopLevelWindow_UpdateButtonVisuals_Org);
 
 			// Crossfade workaround also needed on Win11
@@ -313,6 +354,7 @@ namespace OpenGlass::ButtonGlowHandler
 					{ &g_CAtlasButton_AppendAtlas_Org, &CAtlasButton_AppendAtlas_Hook },
 					{ &g_CAtlasButton_AddApproxAtlasSize_Org, &CAtlasButton_AddApproxAtlasSize_Hook },
 					{ &g_CButton_DrawStateW_Org, &CButton_DrawStateW_Hook },
+					{ &g_CButton_RedrawVisual_Org, &CButton_RedrawVisual_Hook },
 					{ &g_CTopLevelWindow_UpdateButtonVisuals_Org, &CTopLevelWindow_UpdateButtonVisuals_Hook },
 					{ &CTopLevelWindow_CreateGlyphsFromAtlas_Win11, &CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11 },
 					{ &CVisual_SetDirtyFlags_orig, &CVisual_SetDirtyFlags_hook },
@@ -347,6 +389,7 @@ namespace OpenGlass::ButtonGlowHandler
 					{ &g_CAtlasButton_AppendAtlas_Org, &CAtlasButton_AppendAtlas_Hook },
 					{ &g_CAtlasButton_AddApproxAtlasSize_Org, &CAtlasButton_AddApproxAtlasSize_Hook },
 					{ &g_CButton_DrawStateW_Org, &CButton_DrawStateW_Hook },
+					{ &g_CButton_RedrawVisual_Org, &CButton_RedrawVisual_Hook },
 					{ &g_CTopLevelWindow_UpdateButtonVisuals_Org, &CTopLevelWindow_UpdateButtonVisuals_Hook },
 					{ &CTopLevelWindow_CreateGlyphsFromAtlas_Win11, &CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11 },
 					{ &CVisual_SetDirtyFlags_orig, &CVisual_SetDirtyFlags_hook },

--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -101,6 +101,8 @@ namespace OpenGlass::ButtonGlowHandler
 	enum class ButtonGlowType { None, MinMax, Close };
 	std::unordered_map<void*, ButtonGlowType> g_buttonGlowMap;
 
+	HTHEME g_glowThemeHandle{ nullptr };
+
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowMinMax;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowClose;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowToolClose;
@@ -189,8 +191,29 @@ namespace OpenGlass::ButtonGlowHandler
 		return S_OK;
 	}
 
+	// Ensure glow bitmaps are loaded. Called lazily from hooks that need them.
+	void EnsureGlowBitmapsLoaded()
+	{
+		if (g_glowMinMax || g_glowClose)
+			return;
+
+		void* hTheme = g_glowThemeHandle;
+		if (!hTheme && uDWM::CDesktopManager::s_pDesktopManagerInstance)
+		{
+			auto* dm = *uDWM::CDesktopManager::s_pDesktopManagerInstance;
+			if (dm)
+				hTheme = *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(dm) + 69 * 8);
+		}
+		if (!hTheme)
+			return;
+
+		g_glowThemeHandle = static_cast<HTHEME>(hTheme);
+		Win11_LoadGlowBitmaps(hTheme);
+	}
+
 	HRESULT WINAPI CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11(HTHEME hTheme)
 	{
+		g_glowThemeHandle = hTheme;
 		Win11_LoadGlowBitmaps(hTheme);
 		return CTopLevelWindow_CreateGlyphsFromAtlas_Win11(hTheme);
 	}
@@ -198,6 +221,8 @@ namespace OpenGlass::ButtonGlowHandler
 	// Hook: CAtlasButton::AppendAtlas — also add glow nine-grid
 	HRESULT __fastcall CAtlasButton_AppendAtlas_Hook(void* thisButton, void* atlasedRects)
 	{
+		EnsureGlowBitmapsLoaded();
+
 		HRESULT hr = g_CAtlasButton_AppendAtlas_Org(thisButton, atlasedRects);
 		if (FAILED(hr)) return hr;
 
@@ -218,12 +243,14 @@ namespace OpenGlass::ButtonGlowHandler
 		if (!g_AddNineGridAtlasSize)
 			return;
 
-		auto* glowRef = g_glowMinMax.get();
-		if (!glowRef) glowRef = g_glowClose.get();
+		EnsureGlowBitmapsLoaded();
 
 		auto it = g_atlasGlowMap.find(thisButton);
-		if (it != g_atlasGlowMap.end() && it->second)
-			glowRef = it->second.get();
+		uDWM::CBitmapSource* glowRef = (it != g_atlasGlowMap.end() && it->second)
+			? it->second.get() : nullptr;
+
+		if (!glowRef) glowRef = g_glowMinMax.get();
+		if (!glowRef) glowRef = g_glowClose.get();
 
 		if (glowRef)
 		{
@@ -231,6 +258,11 @@ namespace OpenGlass::ButtonGlowHandler
 				reinterpret_cast<uintptr_t>(glowRef) + MARGIN_OFFSET
 			);
 			g_AddNineGridAtlasSize(thisButton, margins, sizeOut);
+		}
+		else
+		{
+			// try to reserve enough space for bitmaps if not loaded yet
+			*sizeOut += 20000;
 		}
 	}
 
@@ -268,6 +300,13 @@ namespace OpenGlass::ButtonGlowHandler
 			if (firstImg)
 				Win11_SetGlowImage(firstImg, glowBitmap);
 
+			if (!glowBitmap)
+			{
+				void* secondImg = *button->GetSecondAtlasImage();
+				if (secondImg)
+					Win11_SetGlowImage(secondImg, nullptr);
+			}
+
 			if (glowBitmap && g_CVisual_MoveToFront)
 				g_CVisual_MoveToFront(thisButton, 0);
 		}
@@ -278,8 +317,9 @@ namespace OpenGlass::ButtonGlowHandler
 	// Hook: CTopLevelWindow::UpdateButtonVisuals — associate our stored glow bitmaps with buttons
 	HRESULT __fastcall CTopLevelWindow_UpdateButtonVisuals_Hook(void* thisWindow, const void* windowFrame)
 	{
-		auto* tlw = reinterpret_cast<uDWM::CTopLevelWindow*>(thisWindow);
+		HRESULT hr = g_CTopLevelWindow_UpdateButtonVisuals_Org(thisWindow, windowFrame);
 
+		auto* tlw = reinterpret_cast<uDWM::CTopLevelWindow*>(thisWindow);
 		auto* helpBtn = tlw->GetButton(0);
 		auto* minBtn = tlw->GetButton(1);
 		auto* maxBtn = tlw->GetButton(2);
@@ -290,7 +330,7 @@ namespace OpenGlass::ButtonGlowHandler
 		if (maxBtn)   g_buttonGlowMap[maxBtn] = ButtonGlowType::MinMax;
 		if (closeBtn) g_buttonGlowMap[closeBtn] = ButtonGlowType::Close;
 
-		return g_CTopLevelWindow_UpdateButtonVisuals_Org(thisWindow, windowFrame);
+		return hr;
 	}
 
 	void Win11_ClearMaps()
@@ -300,6 +340,7 @@ namespace OpenGlass::ButtonGlowHandler
 		g_glowMinMax = nullptr;
 		g_glowClose = nullptr;
 		g_glowToolClose = nullptr;
+		g_glowThemeHandle = nullptr;
 	}
 
 	void Update([[maybe_unused]] GlassEngine::UpdateType type)

--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -306,9 +306,6 @@ namespace OpenGlass::ButtonGlowHandler
 				if (secondImg)
 					Win11_SetGlowImage(secondImg, nullptr);
 			}
-
-			if (glowBitmap && g_CVisual_MoveToFront)
-				g_CVisual_MoveToFront(thisButton, 0);
 		}
 
 		return hr;

--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -103,6 +103,8 @@ namespace OpenGlass::ButtonGlowHandler
 
 	HTHEME g_glowThemeHandle{ nullptr };
 
+	void* g_currentHotButton{ nullptr };
+
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowMinMax;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowClose;
 	winrt::com_ptr<uDWM::CBitmapSource> g_glowToolClose;
@@ -127,6 +129,33 @@ namespace OpenGlass::ButtonGlowHandler
 
 	using fn_CButton_RedrawVisual = HRESULT(__fastcall*)(void*);
 	fn_CButton_RedrawVisual g_CButton_RedrawVisual_Org{ nullptr };
+
+	// change atlas image order within CAtlasedRectsVisual
+	using fn_RemoveAtlasImage = HRESULT(__fastcall*)(void*, void*);
+	using fn_AddAtlasImage = HRESULT(__fastcall*)(void*, void*);
+	using fn_InsertAtlasImageAtIndex = HRESULT(__fastcall*)(void*, void*, unsigned int);
+	fn_RemoveAtlasImage g_RemoveAtlasImage{ nullptr };
+	fn_AddAtlasImage g_AddAtlasImage{ nullptr };
+	fn_InsertAtlasImageAtIndex g_InsertAtlasImageAtIndex{ nullptr };
+
+	// Move atlas image to end of parent's array for highest z-order.
+	void MoveAtlasImageToEnd(void* parent, void* atlasImage)
+	{
+		if (!parent || !atlasImage || !g_RemoveAtlasImage) return;
+
+		if (g_AddAtlasImage) // 24h2+
+		{
+			g_RemoveAtlasImage(parent, atlasImage);
+			g_AddAtlasImage(parent, atlasImage);
+		}
+		else if (g_InsertAtlasImageAtIndex
+			&& uDWM::g_versionInfo.build < os::build_w11_24h2) //21H2-23H2
+		{
+			g_RemoveAtlasImage(parent, atlasImage);
+			auto count = *reinterpret_cast<DWORD*>(reinterpret_cast<uintptr_t>(parent) + 272);
+			g_InsertAtlasImageAtIndex(parent, atlasImage, count);
+		}
+	}
 
 	// Reuse same CreateBitmapFromAtlas as Win10 (still exists on Win11)
 	HRESULT(WINAPI* CTopLevelWindow__CreateBitmapFromAtlas_Win11)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
@@ -306,6 +335,34 @@ namespace OpenGlass::ButtonGlowHandler
 				if (secondImg)
 					Win11_SetGlowImage(secondImg, nullptr);
 			}
+
+			if (glowBitmap)
+				g_currentHotButton = thisButton;
+			else if (g_currentHotButton == thisButton)
+				g_currentHotButton = nullptr;
+		}
+
+		if (g_currentHotButton && g_RemoveAtlasImage)
+		{
+			auto* hotBtn = reinterpret_cast<uDWM::CButton*>(g_currentHotButton);
+			void* hotImg = *hotBtn->GetFirstAtlasImage();
+			if (hotImg)
+			{
+				auto* parent = *reinterpret_cast<void**>(
+					reinterpret_cast<uintptr_t>(hotImg) + 80);
+				if (parent)
+				{
+					if (g_AddAtlasImage || parent != g_currentHotButton)
+					{
+						// Parent is CAtlasedRectsVisual: reorder atlas image array
+						MoveAtlasImageToEnd(parent, hotImg);
+					}
+					else if (g_CVisual_MoveToFront)
+					{
+						g_CVisual_MoveToFront(g_currentHotButton, 0);
+					}
+				}
+			}
 		}
 
 		return hr;
@@ -368,11 +425,13 @@ namespace OpenGlass::ButtonGlowHandler
 		}
 		else
 		{
-			// Win11 21H2+: resolve symbols and install hooks
 			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::AppendAtlasNineGrid", g_AppendAtlasNineGrid);
 			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::AddNineGridAtlasSize", g_AddNineGridAtlasSize);
 			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::SetDirtyFlags", g_AtlasedImage_SetDirtyFlags);
 			uDWM::g_projectionArray.ApplyToVariable("CVisual::MoveToFront", g_CVisual_MoveToFront);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::RemoveAtlasImage", g_RemoveAtlasImage);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::AddAtlasImage", g_AddAtlasImage);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedRectsVisual::InsertAtlasImageAtIndex", g_InsertAtlasImageAtIndex);
 			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateBitmapFromAtlas", CTopLevelWindow__CreateBitmapFromAtlas_Win11);
 			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateGlyphsFromAtlas", CTopLevelWindow_CreateGlyphsFromAtlas_Win11);
 

--- a/OpenGlass/ButtonGlowHandler.cpp
+++ b/OpenGlass/ButtonGlowHandler.cpp
@@ -12,8 +12,8 @@ namespace OpenGlass::ButtonGlowHandler
 	* where offset can be found inside, used to get the image to pass into CButton::SetVisualStates
 	* there will be many calls, but they all get at the same 2 offset, which correspond to these
 	*/
-	constexpr int MINMAXBUTTONGLOWIMAGE = 0xD0; 
-	constexpr int CLOSEBUTTONGLOWIMAGE = 0xC8; 
+	constexpr int MINMAXBUTTONGLOWIMAGE = 0xD0;
+	constexpr int CLOSEBUTTONGLOWIMAGE = 0xC8;
 
 	static int MINMAXBUTTONGLOW = 93; //16 in windows 7
 	static int CLOSEBUTTONGLOW = 92; //11 in windows 7
@@ -92,17 +92,175 @@ namespace OpenGlass::ButtonGlowHandler
 		return CTopLevelWindow_CreateGlyphsFromAtlas(hTheme);
 	}
 
-	// for those people who want to restore button glow on windows 11, you should implement required code for these functions
-	// 
-	// CAtlasButton::AddApproximateAtlasSize
-	// CAtlasButton::AppendAtlas
-	// CAtlasButton::SetGlowImage
-	// CButton::DrawStateW
-	// CButton::SetVisualStates
-	// CTopLevelWindow::UpdateButtonVisuals
-	// (function that loads button glow atlas images from theme)
-	// 
-	// consider using std::unordered_map to store missing glow image member (CAtlasImage)
+	// Win11 21H2+ Button Glow Implementation:
+	// Windows 11 removed the glow image member from CAtlasButton and CButton.
+	// We use external maps to store the glow bitmaps and hook the rendering pipeline.
+
+	std::unordered_map<void*, winrt::com_ptr<uDWM::CBitmapSource>> g_atlasGlowMap;
+	std::unordered_map<void*, winrt::com_ptr<uDWM::CBitmapSource>> g_buttonGlowMap;
+
+	winrt::com_ptr<uDWM::CBitmapSource> g_glowMinMax;
+	winrt::com_ptr<uDWM::CBitmapSource> g_glowClose;
+	winrt::com_ptr<uDWM::CBitmapSource> g_glowToolClose;
+
+	using fn_AppendAtlasNineGrid = HRESULT(__fastcall*)(void*, void*, uDWM::CBitmapSource*);
+	using fn_AddNineGridAtlasSize = void(__fastcall*)(void*, const MARGINS&, unsigned int*);
+	using fn_AtlasedImage_SetDirtyFlags = void(__fastcall*)(void*, unsigned int, unsigned int);
+	using fn_CVisual_MoveToFront = HRESULT(__fastcall*)(void*, int);
+	fn_AppendAtlasNineGrid g_AppendAtlasNineGrid{ nullptr };
+	fn_AddNineGridAtlasSize g_AddNineGridAtlasSize{ nullptr };
+	fn_AtlasedImage_SetDirtyFlags g_AtlasedImage_SetDirtyFlags{ nullptr };
+	fn_CVisual_MoveToFront g_CVisual_MoveToFront{ nullptr };
+
+	// Reuse same CreateBitmapFromAtlas as Win10 (still exists on Win11)
+	HRESULT(WINAPI* CTopLevelWindow__CreateBitmapFromAtlas_Win11)(HTHEME hTheme, int iPartId, MARGINS* outMargins, void** outBitmapSource);
+
+	// Original function pointers for our hooks
+	using fn_CAtlasButton_AppendAtlas = HRESULT(__fastcall*)(void*, void*);
+	using fn_CAtlasButton_AddApproxAtlasSize = void(__fastcall*)(void*, unsigned int*);
+	using fn_CButton_DrawStateW = void(__fastcall*)(void*, void*, unsigned int);
+	using fn_CTopLevelWindow_UpdateButtonVisuals = HRESULT(__fastcall*)(void*, const void*);
+
+	fn_CAtlasButton_AppendAtlas g_CAtlasButton_AppendAtlas_Org{ nullptr };
+	fn_CAtlasButton_AddApproxAtlasSize g_CAtlasButton_AddApproxAtlasSize_Org{ nullptr };
+	fn_CButton_DrawStateW g_CButton_DrawStateW_Org{ nullptr };
+	fn_CTopLevelWindow_UpdateButtonVisuals g_CTopLevelWindow_UpdateButtonVisuals_Org{ nullptr };
+
+	// Theme glyph hook for Win11 (to load glow bitmaps when theme loads)
+	HRESULT(WINAPI* CTopLevelWindow_CreateGlyphsFromAtlas_Win11)(HTHEME hTheme);
+
+	void Win11_SetGlowImage(void* atlasButton, uDWM::CBitmapSource* glow)
+	{
+		auto& stored = g_atlasGlowMap[atlasButton];
+		if (stored.get() != glow)
+		{
+			stored.copy_from(glow);
+			if (g_AtlasedImage_SetDirtyFlags)
+				g_AtlasedImage_SetDirtyFlags(atlasButton, 1u, 0x2000u);
+		}
+	}
+
+	HRESULT Win11_LoadGlowBitmaps(void* hTheme)
+	{
+		if (!CTopLevelWindow__CreateBitmapFromAtlas_Win11)
+			return E_NOTIMPL;
+
+		g_glowMinMax = nullptr;
+		g_glowClose = nullptr;
+		g_glowToolClose = nullptr;
+
+		MARGINS margins{};
+		void* bmp = nullptr;
+
+		if (SUCCEEDED(CTopLevelWindow__CreateBitmapFromAtlas_Win11(static_cast<HTHEME>(hTheme), MINMAXBUTTONGLOW, &margins, &bmp)) && bmp)
+		{
+			*(MARGINS*)(reinterpret_cast<uintptr_t>(bmp) + MARGIN_OFFSET) = margins;
+			g_glowMinMax.attach(static_cast<uDWM::CBitmapSource*>(bmp));
+		}
+
+		bmp = nullptr;
+		if (SUCCEEDED(CTopLevelWindow__CreateBitmapFromAtlas_Win11(static_cast<HTHEME>(hTheme), CLOSEBUTTONGLOW, &margins, &bmp)) && bmp)
+		{
+			*(MARGINS*)(reinterpret_cast<uintptr_t>(bmp) + MARGIN_OFFSET) = margins;
+			g_glowClose.attach(static_cast<uDWM::CBitmapSource*>(bmp));
+		}
+
+		bmp = nullptr;
+		if (SUCCEEDED(CTopLevelWindow__CreateBitmapFromAtlas_Win11(static_cast<HTHEME>(hTheme), TOOLCLOSEBUTTONGLOW, &margins, &bmp)) && bmp)
+		{
+			*(MARGINS*)(reinterpret_cast<uintptr_t>(bmp) + MARGIN_OFFSET) = margins;
+			g_glowToolClose.attach(static_cast<uDWM::CBitmapSource*>(bmp));
+		}
+
+		return S_OK;
+	}
+
+	HRESULT WINAPI CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11(HTHEME hTheme)
+	{
+		Win11_LoadGlowBitmaps(hTheme);
+		return CTopLevelWindow_CreateGlyphsFromAtlas_Win11(hTheme);
+	}
+
+	// Hook: CAtlasButton::AppendAtlas — also add glow nine-grid
+	HRESULT __fastcall CAtlasButton_AppendAtlas_Hook(void* thisButton, void* atlasedRects)
+	{
+		HRESULT hr = g_CAtlasButton_AppendAtlas_Org(thisButton, atlasedRects);
+		if (FAILED(hr)) return hr;
+
+		auto it = g_atlasGlowMap.find(thisButton);
+		if (it != g_atlasGlowMap.end() && it->second && g_AppendAtlasNineGrid)
+		{
+			hr = g_AppendAtlasNineGrid(thisButton, atlasedRects, it->second.get());
+			if (FAILED(hr)) return hr;
+		}
+		return S_OK;
+	}
+
+	// Hook: CAtlasButton::AddApproximateAtlasSize — account for glow
+	void __fastcall CAtlasButton_AddApproxAtlasSize_Hook(void* thisButton, unsigned int* sizeOut)
+	{
+		g_CAtlasButton_AddApproxAtlasSize_Org(thisButton, sizeOut);
+
+		auto it = g_atlasGlowMap.find(thisButton);
+		if (it != g_atlasGlowMap.end() && it->second && g_AddNineGridAtlasSize)
+		{
+			const auto& margins = *reinterpret_cast<const MARGINS*>(
+				reinterpret_cast<uintptr_t>(it->second.get()) + MARGIN_OFFSET
+			);
+			g_AddNineGridAtlasSize(thisButton, margins, sizeOut);
+		}
+	}
+
+	// Hook: CButton::DrawStateW — restore glow rendering
+	void __fastcall CButton_DrawStateW_Hook(void* thisButton, void* atlasedImage, unsigned int state)
+	{
+		g_CButton_DrawStateW_Org(thisButton, atlasedImage, state);
+
+		uDWM::CBitmapSource* glowBitmap = nullptr;
+
+		// States 1 (hot) and 2 (pressed) show glow, matching Win10 logic: (state - 1 <= 1)
+		if (state >= 1 && state <= 2)
+		{
+			auto it = g_buttonGlowMap.find(thisButton);
+			if (it != g_buttonGlowMap.end() && it->second)
+			{
+				// OpenGlass is active, so glass effects are always enabled — no need for
+				// the CDesktopManager byte 17 check (which is build-specific anyway)
+				if (g_CVisual_MoveToFront)
+					g_CVisual_MoveToFront(thisButton, 0);
+				glowBitmap = it->second.get();
+			}
+		}
+
+		Win11_SetGlowImage(atlasedImage, glowBitmap);
+	}
+
+	// Hook: CTopLevelWindow::UpdateButtonVisuals — associate our stored glow bitmaps with buttons
+	HRESULT __fastcall CTopLevelWindow_UpdateButtonVisuals_Hook(void* thisWindow, const void* windowFrame)
+	{
+		auto* tlw = reinterpret_cast<uDWM::CTopLevelWindow*>(thisWindow);
+
+		auto* helpBtn = tlw->GetButton(0);
+		auto* minBtn = tlw->GetButton(1);
+		auto* maxBtn = tlw->GetButton(2);
+		auto* closeBtn = tlw->GetButton(3);
+
+		if (helpBtn)  g_buttonGlowMap[helpBtn].copy_from(g_glowMinMax.get());
+		if (minBtn)   g_buttonGlowMap[minBtn].copy_from(g_glowMinMax.get());
+		if (maxBtn)   g_buttonGlowMap[maxBtn].copy_from(g_glowMinMax.get());
+		if (closeBtn) g_buttonGlowMap[closeBtn].copy_from(g_glowClose.get());
+
+		return g_CTopLevelWindow_UpdateButtonVisuals_Org(thisWindow, windowFrame);
+	}
+
+	void Win11_ClearMaps()
+	{
+		g_atlasGlowMap.clear();
+		g_buttonGlowMap.clear();
+		g_glowMinMax = nullptr;
+		g_glowClose = nullptr;
+		g_glowToolClose = nullptr;
+	}
 
 	void Update([[maybe_unused]] GlassEngine::UpdateType type)
 	{
@@ -130,6 +288,39 @@ namespace OpenGlass::ButtonGlowHandler
 				true
 			);
 		}
+		else
+		{
+			// Win11 21H2+: resolve symbols and install hooks
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::AppendAtlasNineGrid", g_AppendAtlasNineGrid);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::AddNineGridAtlasSize", g_AddNineGridAtlasSize);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasedImage::SetDirtyFlags", g_AtlasedImage_SetDirtyFlags);
+			uDWM::g_projectionArray.ApplyToVariable("CVisual::MoveToFront", g_CVisual_MoveToFront);
+			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateBitmapFromAtlas", CTopLevelWindow__CreateBitmapFromAtlas_Win11);
+			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::CreateGlyphsFromAtlas", CTopLevelWindow_CreateGlyphsFromAtlas_Win11);
+
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasButton::AppendAtlas", g_CAtlasButton_AppendAtlas_Org);
+			uDWM::g_projectionArray.ApplyToVariable("CAtlasButton::AddApproximateAtlasSize", g_CAtlasButton_AddApproxAtlasSize_Org);
+			uDWM::g_projectionArray.ApplyToVariable("CButton::DrawStateW", g_CButton_DrawStateW_Org);
+			uDWM::g_projectionArray.ApplyToVariable("CTopLevelWindow::UpdateButtonVisuals", g_CTopLevelWindow_UpdateButtonVisuals_Org);
+
+			// Crossfade workaround also needed on Win11
+			uDWM::g_projectionArray.ApplyToVariable("CVisual::SetDirtyFlags", CVisual_SetDirtyFlags_orig);
+			uDWM::g_projectionArray.ApplyToVariable("CButton::UpdateCrossfade", CButton_UpdateCrossfade_orig);
+
+			HookHelper::PatchFunctions(
+				std::initializer_list<HookHelper::DetourInfo>
+				{
+					{ &g_CAtlasButton_AppendAtlas_Org, &CAtlasButton_AppendAtlas_Hook },
+					{ &g_CAtlasButton_AddApproxAtlasSize_Org, &CAtlasButton_AddApproxAtlasSize_Hook },
+					{ &g_CButton_DrawStateW_Org, &CButton_DrawStateW_Hook },
+					{ &g_CTopLevelWindow_UpdateButtonVisuals_Org, &CTopLevelWindow_UpdateButtonVisuals_Hook },
+					{ &CTopLevelWindow_CreateGlyphsFromAtlas_Win11, &CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11 },
+					{ &CVisual_SetDirtyFlags_orig, &CVisual_SetDirtyFlags_hook },
+					{ &CButton_UpdateCrossfade_orig, &CButton_UpdateCrossfade_hook }
+				},
+				true
+			);
+		}
 	}
 
 	void Shutdown()
@@ -147,6 +338,25 @@ namespace OpenGlass::ButtonGlowHandler
 			);
 
 			SwitchToThread();
+		}
+		else
+		{
+			HookHelper::PatchFunctions(
+				std::initializer_list<HookHelper::DetourInfo>
+				{
+					{ &g_CAtlasButton_AppendAtlas_Org, &CAtlasButton_AppendAtlas_Hook },
+					{ &g_CAtlasButton_AddApproxAtlasSize_Org, &CAtlasButton_AddApproxAtlasSize_Hook },
+					{ &g_CButton_DrawStateW_Org, &CButton_DrawStateW_Hook },
+					{ &g_CTopLevelWindow_UpdateButtonVisuals_Org, &CTopLevelWindow_UpdateButtonVisuals_Hook },
+					{ &CTopLevelWindow_CreateGlyphsFromAtlas_Win11, &CTopLevelWindow_CreateGlyphsFromAtlas_Hook_Win11 },
+					{ &CVisual_SetDirtyFlags_orig, &CVisual_SetDirtyFlags_hook },
+					{ &CButton_UpdateCrossfade_orig, &CButton_UpdateCrossfade_hook }
+				},
+				false
+			);
+
+			SwitchToThread();
+			Win11_ClearMaps();
 		}
 	}
 }

--- a/OpenGlass/uDwmProjection.Offsets.hpp
+++ b/OpenGlass/uDwmProjection.Offsets.hpp
@@ -204,6 +204,31 @@ namespace OpenGlass::uDWM
 		}
 	};
 
+	struct CButton_GetVisualState_Offsets {
+		consteval static auto operator()(){
+			return std::array{
+				Util::OffsetInfo{ .offset = 376, .build = os::build_w11_24h2, .revision = 0 },
+				Util::OffsetInfo{ .offset = 328, .build = 0, .revision = 0 }
+			};
+		}
+	};
+	struct CButton_GetFirstAtlasImage_Offsets {
+		consteval static auto operator()(){
+			return std::array{
+				Util::OffsetInfo{ .offset = 296, .build = os::build_w11_24h2, .revision = 0 },
+				Util::OffsetInfo{ .offset = 248, .build = 0, .revision = 0 }
+			};
+		}
+	};
+	struct CButton_GetSecondAtlasImage_Offsets {
+		consteval static auto operator()(){
+			return std::array{
+				Util::OffsetInfo{ .offset = 304, .build = os::build_w11_24h2, .revision = 0 },
+				Util::OffsetInfo{ .offset = 256, .build = 0, .revision = 0 }
+			};
+		}
+	};
+
 	struct CAccent_GetAccentPolicy_Offsets {
 		consteval static auto operator()(){
 			return std::array{

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -553,6 +553,18 @@ namespace OpenGlass::uDWM
 		{
 			return Util::PointerExecuteUnsafe<CButton_GetButtonState_Offsets, Util::OffsetBy<BYTE*>>(this, g_versionInfo.build, g_versionInfo.revision);
 		}
+		DECLSPEC_PROJECTION DWORD* GetVisualState()
+		{
+			return Util::PointerExecuteUnsafe<CButton_GetVisualState_Offsets, Util::OffsetBy<DWORD*>>(this, g_versionInfo.build, g_versionInfo.revision);
+		}
+		DECLSPEC_PROJECTION void** GetFirstAtlasImage()
+		{
+			return Util::PointerExecuteUnsafe<CButton_GetFirstAtlasImage_Offsets, Util::OffsetBy<void**>>(this, g_versionInfo.build, g_versionInfo.revision);
+		}
+		DECLSPEC_PROJECTION void** GetSecondAtlasImage()
+		{
+			return Util::PointerExecuteUnsafe<CButton_GetSecondAtlasImage_Offsets, Util::OffsetBy<void**>>(this, g_versionInfo.build, g_versionInfo.revision);
+		}
 		DECLSPEC_PROJECTION CTimeline* GetTimeline()
 		{
 			return *Util::PointerExecuteUnsafe<CButton_GetTimeline_Offsets, Util::OffsetBy<CTimeline**>>(this, g_versionInfo.build, g_versionInfo.revision);
@@ -1369,6 +1381,7 @@ namespace OpenGlass::uDWM
 
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateButtonVisuals", os::build_w11_21h2, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::MoveToFront", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::RedrawVisual", os::build_w11_21h2, 0),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CRenderDataVisual::Create_Pre_W10_1903, "CRenderDataVisual::Create", 0, os::build_w10_1903),

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -1357,7 +1357,18 @@ namespace OpenGlass::uDWM
 		MAKE_FUNCTION_PROJECTION_TUPLE(CButton::Create, os::build_w10_2004 , os::build_w11_22h2),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CButton::SetVisualStates_Win10, "CButton::SetVisualStates", 0, os::build_w11_21h2),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CButton::SetVisualStates_Win11, "CButton::SetVisualStates", os::build_w11_21h2, os::build_w11_22h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CButton::UpdateCrossfade", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::UpdateCrossfade", 0, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CButton::DrawStateW", os::build_w11_21h2, 0),
+
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasButton::AppendAtlas", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasButton::AddApproximateAtlasSize", os::build_w11_21h2, 0),
+
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedImage::AppendAtlasNineGrid", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedImage::AddNineGridAtlasSize", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedImage::SetDirtyFlags", os::build_w11_21h2, 0),
+
+		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateButtonVisuals", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::MoveToFront", os::build_w11_21h2, 0),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CRenderDataVisual::Create_Pre_W10_1903, "CRenderDataVisual::Create", 0, os::build_w10_1903),
@@ -1389,8 +1400,8 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateWindowVisuals", os::build_w11_21h2, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::~CTopLevelWindow", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::IsShadowNCAreaPart", os::build_w11_24h2, 0),
-		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::CreateBitmapFromAtlas", 0, os::build_w11_21h2),
-		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::CreateGlyphsFromAtlas", 0, os::build_w11_21h2),
+		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::CreateBitmapFromAtlas", 0, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::CreateGlyphsFromAtlas", 0, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::EnsureImages", 0, os::build_w11_24h2),
 		MAKE_EMPTY_PROJECTION_TUPLE("SetMargin", os::build_w11_21h2, 0),
 

--- a/OpenGlass/uDwmProjection.hpp
+++ b/OpenGlass/uDwmProjection.hpp
@@ -1382,6 +1382,9 @@ namespace OpenGlass::uDWM
 		MAKE_EMPTY_PROJECTION_TUPLE("CTopLevelWindow::UpdateButtonVisuals", os::build_w11_21h2, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CVisual::MoveToFront", os::build_w11_21h2, 0),
 		MAKE_EMPTY_PROJECTION_TUPLE("CButton::RedrawVisual", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::RemoveAtlasImage", os::build_w11_21h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::AddAtlasImage", os::build_w11_24h2, 0),
+		MAKE_EMPTY_PROJECTION_TUPLE("CAtlasedRectsVisual::InsertAtlasImageAtIndex", os::build_w11_21h2, 0),
 
 		MAKE_FUNCTION_PROJECTION_TUPLE(CDrawGeometryInstruction::Create, 0, 0),
 		MAKE_FUNCTION_PROJECTION_TUPLE_BY_ALIAS(CRenderDataVisual::Create_Pre_W10_1903, "CRenderDataVisual::Create", 0, os::build_w10_1903),


### PR DESCRIPTION
This restores the caption button hover/press glow effect on Windows 11, which was previously removed.

Uses the suggested std::unordered_map for storing the glow bitmaps, which we need to do now since the CAtlasImage member was removed from CAtlasButton and alike. This should work on all versions of Windows 11, but only tested on Windows 11 24H2 so far.

Hooks added include:
CAtlasButton::AppendAtlas -- adds glow nine-grid image to the button atlas
CAtlasButton:AddApproximateAtlasSize -- takes the glow image into account for atlas size calculations
CButton:DrawStateW -- restores the glow rendering based on hover/pressed state
CTopLevelWindow::UpdateButtonVisuals -- associates the glow bitmaps w/ each of caption buttons
CTopLevelWindow::CreateGlyphFromAtlas -- loads the glow bitmaps from the theme atlas
<img width="186" height="77" alt="close" src="https://github.com/user-attachments/assets/c7ae07fb-a36e-441a-87e8-93df5dceab19" />
<img width="143" height="78" alt="restore" src="https://github.com/user-attachments/assets/c17bc56f-3061-4ab7-9d2b-935092fa41aa" />
<img width="179" height="87" alt="minimize" src="https://github.com/user-attachments/assets/e04b7873-8245-4239-ab0b-565b1405256e" />
