### PR TITLE
docs(README): fix 'Cannary' -> 'Canary' (Windows release channel name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This utility returns the full glass effect to the window frame like [glass8](htt
 > **OpenGlass is not supported on Windows 11 26H1 or any versions with build 28000 and above.** Microsoft has removed the legacy MIL infrastructure in these builds, which makes it impossible for OpenGlass to continue supporting them. See [#260](https://github.com/ALTaleX531/OpenGlass/issues/260) for details.
 
 > [!NOTE]
-> OpenGlass only supports Windows builds from the General Availability channel. Builds from other channels (such as Cannary, Dev, Release Preview and Beta) and Windows Server versions other than 2022 are **NOT supported**. Running on unsupported builds can crash DWM.
+> OpenGlass only supports Windows builds from the General Availability channel. Builds from other channels (such as Canary, Dev, Release Preview and Beta) and Windows Server versions other than 2022 are **NOT supported**. Running on unsupported builds can crash DWM.
 
 ## Who should use OpenGlass?
 


### PR DESCRIPTION
## Summary
Single-word typo fix in `README.md` line 19: the Windows release channel name is `Canary`, not `Cannary`.

```diff
- Builds from other channels (such as Cannary, Dev, Release Preview and Beta)
+ Builds from other channels (such as Canary, Dev, Release Preview and Beta)
```

## Verification
- `grep -n Cannary README.md` → no matches after the change.

## Note
Co-developed with AI assistance; reviewed and tested by submitter.