### PR TITLE
Windows 8 style caption text centering

### DIFF
--- a/OpenGlass/CaptionTextHandler.cpp
+++ b/OpenGlass/CaptionTextHandler.cpp
@@ -123,7 +123,28 @@ namespace OpenGlass::CaptionTextHandler
 
 	int g_textGlowSize{};
 	int g_textGlowIntensity{};
-	bool g_centerCaption{ false };
+	int g_centerCaption{ 0 };
+	int CaptionCenterOffset(double visualWidth, double textWidth, double visualX, double parentWidth, double scale)
+	{
+		const int localOffset = std::max(
+			static_cast<int>((visualWidth - textWidth) / 2.0),
+			0
+		);
+		if (g_centerCaption <= 0)
+			return 0;
+
+		if (g_centerCaption == 1)
+			return localOffset;
+
+		// Win8 centers against the parent visual and uses a small scale-adjusted
+		// guard band before falling back to the local visual width.
+		int parentOffset = static_cast<int>((parentWidth - textWidth) / 2.0) - static_cast<int>(visualX);
+		if (static_cast<double>(parentOffset + static_cast<int>(textWidth)) + scale * 5.0 > visualWidth)
+			parentOffset = localOffset;
+
+		return std::max(parentOffset, 0);
+	}
+
 
 	void CalculateRealizedTextGlowParams(int textGlowMode);
 }
@@ -201,7 +222,14 @@ int WINAPI CaptionTextHandler::MyDrawTextW(
 		LONG offset = 0;
 		offset += windowState.windowRectLeft;
 		offset -= g_textVisual->GetX();
-		offset -= g_centerCaption ? static_cast<LONG>(std::round(static_cast<DOUBLE>(g_textVisual->GetWidth() - g_textSize.cx) / 2.)) : 0l;
+		// Keep the glow clip rect aligned with the same centering offset as the text.
+		offset -= CaptionCenterOffset(
+			static_cast<DOUBLE>(g_textVisual->GetWidth()),
+			static_cast<DOUBLE>(g_textSize.cx),
+			static_cast<DOUBLE>(g_textVisual->GetX()),
+			static_cast<DOUBLE>(g_textVisual->GetTransformParent()->GetWidth()),
+			g_textVisual->GetScale().width
+		);
 		if (!mirrored)
 		{
 			glowClipRect.left = std::max(
@@ -436,9 +464,16 @@ HRESULT CaptionTextHandler::MyCChannel_MatrixTransformUpdate(dwmcore::CChannel* 
 		matrix->DX -= static_cast<DOUBLE>(g_textGlowSize);
 		matrix->DY -= static_cast<DOUBLE>(g_textGlowSize);
 
-		if (g_centerCaption)
+		// Apply the same CenterCaption offset to the legacy text transform.
+		const DOUBLE offset = static_cast<DOUBLE>(CaptionCenterOffset(
+			static_cast<DOUBLE>(g_textVisual->GetWidth()),
+			static_cast<DOUBLE>(g_textSize.cx),
+			static_cast<DOUBLE>(g_textVisual->GetX()),
+			static_cast<DOUBLE>(g_textVisual->GetTransformParent()->GetWidth()),
+			g_textVisual->GetScale().width
+		));
+		if (offset > 0.0)
 		{
-			const auto offset = std::round(static_cast<DOUBLE>(g_textVisual->GetWidth() - g_textSize.cx) / 2.);
 			matrix->DX += g_textVisual->IsRTLMirrored() ? -offset : offset;
 		}
 	}
@@ -673,7 +708,14 @@ void CaptionTextHandler::MyID2D1DeviceContext_DrawTextLayout(
 			LONG offset = 0;
 			offset += windowState.windowRectLeft;
 			offset -= g_dwriteTextVisual->GetX();
-			offset -= g_centerCaption ? static_cast<LONG>(std::round((static_cast<float>(g_dwriteTextVisual->GetWidth()) - g_textSizeF.Width) / 2.f)) : 0l;
+			// DWrite glow clipping needs the same offset calculation as the text surface.
+			offset -= CaptionCenterOffset(
+				static_cast<double>(g_dwriteTextVisual->GetWidth()),
+				static_cast<double>(g_textSizeF.Width),
+				static_cast<double>(g_dwriteTextVisual->GetX()),
+				static_cast<double>(g_dwriteTextVisual->GetTransformParent()->GetWidth()),
+				g_dwriteTextVisual->GetScale().width
+			);
 			if (!mirrored)
 			{
 				glowClipRect.left = std::max(
@@ -776,9 +818,16 @@ HRESULT CaptionTextHandler::MyICompositionSurfaceBrush2_put_Offset(
 			value.X += offset.x - std::max(offset.x - g_textGlowSize, 0l);
 		}
 
-		if (g_centerCaption)
+		// Apply the same CenterCaption offset to the DWrite composition surface.
+		const float offset = static_cast<float>(CaptionCenterOffset(
+			static_cast<double>(g_dwriteTextVisual->GetWidth()),
+			static_cast<double>(g_textSizeF.Width),
+			static_cast<double>(g_dwriteTextVisual->GetX()),
+			static_cast<double>(g_dwriteTextVisual->GetTransformParent()->GetWidth()),
+			g_dwriteTextVisual->GetScale().width
+		));
+		if (offset > 0.0f)
 		{
-			const auto offset = std::round((static_cast<float>(g_dwriteTextVisual->GetWidth()) - g_textSizeF.Width) / 2.f);
 			value.X += g_dwriteTextVisual->IsRTLMirrored() ? -offset : offset;
 		}
 	}
@@ -999,7 +1048,7 @@ void CaptionTextHandler::Update(GlassEngine::UpdateType type)
 	}
 	if (type & GlassEngine::UpdateType::Backdrop || type & GlassEngine::UpdateType::Theme)
 	{
-		g_centerCaption = static_cast<bool>(GlassEngine::GetDwordFromRegistry(L"CenterCaption", FALSE));
+		g_centerCaption = std::clamp(static_cast<int>(GlassEngine::GetDwordFromRegistry(L"CenterCaption", FALSE)), 0, 2);
 		g_captionActiveColor = GlassEngine::GetDwordFromRegistry(L"ColorizationColorCaption", 0xFFFFFFFD);
 		g_captionInactiveColor = GlassEngine::GetDwordFromRegistry(L"ColorizationColorCaptionInactive", g_captionActiveColor);
 		g_captionActiveColorMaximized = GlassEngine::GetDwordFromRegistry(L"ColorizationColorCaptionMaximized", g_captionActiveColor);

--- a/OpenGlassGUI/MainFrame.Core.cpp
+++ b/OpenGlassGUI/MainFrame.Core.cpp
@@ -1215,15 +1215,16 @@ namespace OpenGlass
 				updateDword(L"CaptionButtons", sel);
 			}
 		});
-		m_chkCenterCaption->Bind(wxEVT_CHECKBOX, [this, updateDword, deleteValue]([[maybe_unused]] wxCommandEvent& e) {
-			if (!e.IsChecked())
+		m_chCenterCaption->Bind(wxEVT_CHOICE, [this, updateDword, deleteValue]([[maybe_unused]] wxCommandEvent& e) {
+			int sel = e.GetSelection();
+			if (sel == 0)
 			{
 				deleteValue(L"CenterCaption");
 				NotifySettingsChange(ChangeType::Theme);
 			}
 			else
 			{
-				updateDword(L"CenterCaption", 1, ChangeType::Theme);
+				updateDword(L"CenterCaption", sel, ChangeType::Theme);
 			}
 		});
 		m_chkDisableModernBorders->Bind(wxEVT_CHECKBOX, [this, updateDword, deleteValue]([[maybe_unused]] wxCommandEvent& e) {

--- a/OpenGlassGUI/MainFrame.State.cpp
+++ b/OpenGlassGUI/MainFrame.State.cpp
@@ -213,7 +213,7 @@ namespace OpenGlass
 		m_scTextGlowSize->Enable(glowMode == 3);
 
 		m_chCaptionButtons->SetSelection(std::clamp<int>(m_config->GetDword(L"CaptionButtons", 0), 0, 3));
-		m_chkCenterCaption->SetValue(m_config->GetDword(L"CenterCaption", 0) != 0);
+		m_chCenterCaption->SetSelection(std::clamp<int>(m_config->GetDword(L"CenterCaption", 0), 0, 2));
 		m_chkDisableModernBorders->SetValue(m_config->GetDword(L"DisableModernBorders", 0) != 0);
 
 		// Colors

--- a/OpenGlassGUI/MainFrame.Tabs.cpp
+++ b/OpenGlassGUI/MainFrame.Tabs.cpp
@@ -274,8 +274,15 @@ namespace OpenGlass
 		// Center Caption
 		{
 			wxBoxSizer* row = new wxBoxSizer(wxHORIZONTAL);
-			m_chkCenterCaption = new wxCheckBox(panel, wxID_ANY, L"Align text to the center");
-			row->Add(m_chkCenterCaption, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+			wxStaticText* label = new wxStaticText(panel, wxID_ANY, L"Caption centering:", wxDefaultPosition, wxSize(300, -1));
+			row->Add(label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+
+			wxArrayString modes;
+			modes.Add(L"Disabled");
+			modes.Add(L"Regular");
+			modes.Add(L"Windows 8 style");
+			m_chCenterCaption = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, modes);
+			row->Add(m_chCenterCaption, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
 			AddOptionStatus(panel, row, L"CenterCaption");
 			textGroup->Add(row, 0, wxEXPAND | wxALL, 2);
 		}

--- a/OpenGlassGUI/MainFrame.hpp
+++ b/OpenGlassGUI/MainFrame.hpp
@@ -109,7 +109,7 @@ namespace OpenGlass
 		wxSpinCtrl* m_scTextGlowSize{ nullptr }; // Added
 		
 		wxChoice* m_chCaptionButtons{ nullptr };
-		wxCheckBox* m_chkCenterCaption{ nullptr };
+		wxChoice* m_chCenterCaption{ nullptr };
 		wxCheckBox* m_chkDisableModernBorders{ nullptr };
 		wxButton* m_btnExportAtlas{ nullptr };
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you encounter crashes or technical bugs:
 | Key Name | Type | Description |
 | -------- | ---- | ----------- |
 | CaptionButtons | DWORD | Changes caption buttons sizes, icon left margin and the opacity of the button glyphs.<br><br><ul><li>0x0 = Vanilla style (default)</li><li>0x1 = Windows Vista style</li><li>0x2 = Windows 7 style</li><li>0x3 = Windows 8 style</li></ul> |
-| CenterCaption | DWORD | Controls how title bar text is aligned.<br><br><ul><li>0x0 = Keeps it on the left (default)</li><li>0x1 = Centers it between the titlebar icon and the titlebar buttons</li></ul> |
+| CenterCaption | DWORD | Controls how title bar text is aligned.<br><br><ul><li>0x0 = Keeps it on the left (default)</li><li>0x1 = Regular centering</li><li>0x2 = Windows 8 style centering</li></ul> |
 | TextGlowMode | DWORD | Specifies how window caption glow effect will be rendered <br><br><ul><li>0x0 = No glow effect</li><li>0x1 = Glow effect loaded from atlas (default)</li><li>0x2 = Glow effect loaded from atlas and theme opacity is respected</li><li>0x3 = Composited glow effect using your theme settings HIWORD of the value specifies glow size (0 = theme default)</li></ul> |
 | CustomThemeAtlas | String | Path to PNG file with theme resource (bitmap must have exactly the same layout as msstyle theme you are using!). <br><br>💡 OpenGlass also looks for a `.layout` file with the same name (e.g., `theme.png.layout`) to determine the layout of the atlas. |
 | DisableModernBorders | DWORD | Disable modern rounded window borders. <br><br><ul><li>0x0 = Enable modern borders (default)</li><li>0x1 = Disable modern borders</li></ul><br>ℹ️ Only effective in Win11 |


### PR DESCRIPTION
This PR reimplements Windows 8's style of caption text centering (CenterCaption with the value of 2).

This option was available in OpenGlass-8 but me and @nt5point1 have decided that it would fit best into regular OpenGlass as well. (Also it has been improved a bit from that version)

<details>
  <summary>Centering comparation from Windows 10 and 8</summary>
Windows 10 (The lone button is bigger on Windows 8's preset for some reason. Otherwise the text positioning is correct):
<img width="413" height="213" alt="image" src="https://github.com/user-attachments/assets/ca08e48c-b649-4aa7-a831-712a0aa80899" />

Windows 8:
<img width="413" height="213" alt="image" src="https://github.com/user-attachments/assets/81595ea1-7e0a-467e-9430-3d68a4ec5a27" />

Windows 10:
<img width="474" height="413" alt="image" src="https://github.com/user-attachments/assets/27e59914-e762-4a24-9736-1a7005d72cb8" />

Windows 8:
<img width="474" height="413" alt="image" src="https://github.com/user-attachments/assets/eb26cb86-ffb3-4133-9ccc-9400a00d1d15" />
</details>

This style of centering has its own quirks with small windows as shown here:

Windows 10:
<img width="445" height="225" alt="image" src="https://github.com/user-attachments/assets/669662e0-68ff-4db0-91bb-ef6d6adf0465" />

Windows 8:
<img width="474" height="237" alt="image" src="https://github.com/user-attachments/assets/8da085b4-c31d-4f6f-84e3-a6828d1be972" />

Some inaccuracy issues with this style compared to Windows 8 that I haven't figured out if it's something related to the drawn text or something else.

The text seems to be bolder on Windows 10 (and the icon is shifted to the right slightly which might be something else)
Windows 10:
<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/89a988f8-b7bd-4604-a85e-03cbdd39bfad" />

Windows 8:
<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/0a57e0fe-5fd7-4813-bea6-9f415991353f" />

